### PR TITLE
feat: Typosquatting tespit motorunu gelistir — 6 yeni tespit yontemi

### DIFF
--- a/src/detector/url-checker.ts
+++ b/src/detector/url-checker.ts
@@ -107,13 +107,49 @@ export function levenshteinDistance(a: string, b: string): number {
 
   for (let i = 1; i <= m; i++) {
     for (let j = 1; j <= n; j++) {
-      dp[i][j] =
-        a[i - 1] === b[j - 1]
-          ? dp[i - 1][j - 1]
-          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1, // deletion
+        dp[i][j - 1] + 1, // insertion
+        dp[i - 1][j - 1] + cost, // substitution
+      );
+
+      // Damerau extension: transposition of two adjacent characters costs 1
+      if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
+        dp[i][j] = Math.min(dp[i][j], dp[i - 2][j - 2] + cost);
+      }
     }
   }
   return dp[m][n];
+}
+
+// Common unicode confusables: Cyrillic/Greek lookalikes → Latin equivalents
+const CONFUSABLES: Record<string, string> = {
+  "\u0430": "a", // Cyrillic а
+  "\u0435": "e", // Cyrillic е
+  "\u043E": "o", // Cyrillic о
+  "\u0440": "p", // Cyrillic р
+  "\u0441": "c", // Cyrillic с
+  "\u0443": "y", // Cyrillic у
+  "\u0445": "x", // Cyrillic х
+  "\u0456": "i", // Cyrillic і
+  "\u0261": "g", // Latin small script g
+  "\u03B1": "a", // Greek α
+  "\u03BF": "o", // Greek ο
+  "\u03B5": "e", // Greek ε
+  "\u0131": "i", // Turkish dotless ı
+};
+
+export function normalizeHomoglyphs(input: string): string {
+  let result = "";
+  for (const char of input) {
+    result += CONFUSABLES[char] ?? char;
+  }
+  return result;
+}
+
+function stripSeparators(name: string): string {
+  return name.replace(/[-_.]/g, "");
 }
 
 function extractName(rootDomain: string): string {
@@ -121,15 +157,23 @@ function extractName(rootDomain: string): string {
   return rootDomain.split(".")[0];
 }
 
-export function checkTyposquatting(domain: string): { isSuspicious: boolean; similarTo: string | null } {
+export function checkTyposquatting(
+  domain: string,
+): { isSuspicious: boolean; similarTo: string | null; reason: string | null } {
   const root = extractRootDomain(domain);
 
   // If the domain itself is trusted, no typosquatting
   if (TRUSTED_DOMAINS.has(root)) {
-    return { isSuspicious: false, similarTo: null };
+    return { isSuspicious: false, similarTo: null, reason: null };
   }
 
-  const name = extractName(root);
+  const rawName = extractName(root);
+  const normalizedName = normalizeHomoglyphs(rawName);
+  const strippedName = stripSeparators(normalizedName);
+
+  // Check all subdomain parts for trusted name hiding (e.g. garanti.evil.com)
+  const subdomainParts = domain.split(".");
+  const allParts = subdomainParts.length > 2 ? subdomainParts.slice(0, -2) : [];
 
   for (const trusted of TRUSTED_DOMAINS) {
     const trustedRoot = extractRootDomain(trusted);
@@ -137,13 +181,61 @@ export function checkTyposquatting(domain: string): { isSuspicious: boolean; sim
 
     if (root === trustedRoot) continue;
 
-    const distance = levenshteinDistance(name, trustedName);
-    // If very similar but not identical, it's suspicious
+    // Skip very short trusted names (≤2 chars) to avoid false positives
+    if (trustedName.length <= 2) continue;
+
+    // Check 1: Same name but different TLD (turkiye.com vs turkiye.gov.tr)
+    if (normalizedName === trustedName || strippedName === trustedName) {
+      return {
+        isSuspicious: true,
+        similarTo: trusted,
+        reason: "tld-mismatch",
+      };
+    }
+
+    // Check 2: Damerau-Levenshtein distance ≤ 2 (classic typosquatting)
+    const distance = levenshteinDistance(strippedName, trustedName);
     if (distance > 0 && distance <= 2) {
-      return { isSuspicious: true, similarTo: trusted };
+      return {
+        isSuspicious: true,
+        similarTo: trusted,
+        reason: "edit-distance",
+      };
+    }
+
+    // Check 3: Trusted name contained as substring (securegaranti.com.tr)
+    // Only for names long enough to avoid false positives (≥5 chars)
+    if (trustedName.length >= 5 && strippedName.length > trustedName.length) {
+      if (strippedName.includes(trustedName)) {
+        return {
+          isSuspicious: true,
+          similarTo: trusted,
+          reason: "contains-trusted-name",
+        };
+      }
+    }
+
+    // Check 4: Subdomain hiding (garanti.evil.com, isbank.phishing.net)
+    for (const part of allParts) {
+      const normalizedPart = normalizeHomoglyphs(part);
+      if (normalizedPart === trustedName) {
+        return {
+          isSuspicious: true,
+          similarTo: trusted,
+          reason: "subdomain-impersonation",
+        };
+      }
+      const partDistance = levenshteinDistance(normalizedPart, trustedName);
+      if (trustedName.length >= 4 && partDistance > 0 && partDistance <= 2) {
+        return {
+          isSuspicious: true,
+          similarTo: trusted,
+          reason: "subdomain-typosquat",
+        };
+      }
     }
   }
-  return { isSuspicious: false, similarTo: null };
+  return { isSuspicious: false, similarTo: null, reason: null };
 }
 
 export function checkUrl(
@@ -185,8 +277,16 @@ export function checkUrl(
   // Medium + High: typosquatting check
   const typo = checkTyposquatting(domain);
   if (typo.isSuspicious) {
-    score += 70;
-    reasons.push(`${typo.similarTo} ile benzer domain (olasi sahte site)`);
+    const reasonLabels: Record<string, { score: number; text: string }> = {
+      "edit-distance": { score: 70, text: "benzer domain (olasi sahte site)" },
+      "tld-mismatch": { score: 60, text: "ayni isim farkli uzanti (olasi sahte site)" },
+      "contains-trusted-name": { score: 50, text: "guvenilir ismi iceriyor (olasi sahte site)" },
+      "subdomain-impersonation": { score: 65, text: "alt alan adinda guvenilir isim (olasi sahte site)" },
+      "subdomain-typosquat": { score: 55, text: "alt alan adinda benzer isim (olasi sahte site)" },
+    };
+    const match = reasonLabels[typo.reason ?? ""] ?? { score: 70, text: "benzer domain" };
+    score += match.score;
+    reasons.push(`${typo.similarTo} ile ${match.text}`);
   }
 
   // Medium + High: suspicious keyword check

--- a/tests/detector/typosquatting-deep.test.ts
+++ b/tests/detector/typosquatting-deep.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Deep exploration of the improved typosquatting detection system.
+ *
+ * Tests cover:
+ * 1. Damerau-Levenshtein (transpositions cost 1, not 2)
+ * 2. Same name / different TLD detection
+ * 3. Subdomain impersonation detection
+ * 4. Substring/contains detection for long prefixes
+ * 5. Unicode homoglyph normalization
+ * 6. Separator stripping (hyphens, dots)
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  levenshteinDistance,
+  checkTyposquatting,
+  checkUrl,
+  loadBlocklist,
+  normalizeHomoglyphs,
+} from "@/detector/url-checker";
+import { ThreatLevel } from "@/utils/types";
+
+beforeEach(() => {
+  loadBlocklist([], true);
+});
+
+// ─── DAMERAU-LEVENSHTEIN (IMPROVEMENT #4) ─────────────────────────
+describe("Damerau-Levenshtein — transpositions now cost 1", () => {
+  it("adjacent swap costs 1, not 2 (garanti → garanit)", () => {
+    // Old Levenshtein: 2 (delete + insert)
+    // New Damerau-Levenshtein: 1 (single transposition)
+    expect(levenshteinDistance("garanti", "garanit")).toBe(1);
+  });
+
+  it("adjacent swap costs 1 (paypal → paypla)", () => {
+    expect(levenshteinDistance("paypal", "paypla")).toBe(1);
+  });
+
+  it("non-adjacent swap still costs 2 (abcde → aedcb)", () => {
+    // Only adjacent transpositions are cheap
+    expect(levenshteinDistance("abcde", "aedcb")).toBeGreaterThan(1);
+  });
+
+  it("transposition now opens room for more detection", () => {
+    // "garanit" (transposition) + one more edit = distance 2, still caught
+    // Before: distance was 2 for just the transposition, leaving no room
+    const result = checkTyposquatting("garanitt.com.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("garanti.com.tr");
+  });
+});
+
+// ─── SAME NAME, DIFFERENT TLD (IMPROVEMENT #1) ───────────────────
+describe("Same name, different TLD — NOW CAUGHT", () => {
+  it("catches turkiye.com (same name as turkiye.gov.tr)", () => {
+    const result = checkTyposquatting("turkiye.com");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("turkiye.gov.tr");
+    expect(result.reason).toBe("tld-mismatch");
+  });
+
+  it("catches isbank.com (same name as isbank.com.tr)", () => {
+    const result = checkTyposquatting("isbank.com");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("isbank.com.tr");
+    expect(result.reason).toBe("tld-mismatch");
+  });
+
+  it("catches garanti.net (same name as garanti.com.tr)", () => {
+    const result = checkTyposquatting("garanti.net");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("garanti.com.tr");
+    expect(result.reason).toBe("tld-mismatch");
+  });
+
+  it("catches ziraatbank.org (same name as ziraatbank.com.tr)", () => {
+    const result = checkTyposquatting("ziraatbank.org");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("ziraatbank.com.tr");
+    expect(result.reason).toBe("tld-mismatch");
+  });
+
+  it("does NOT flag completely different names on common TLDs", () => {
+    const result = checkTyposquatting("randomshop.com");
+    expect(result.isSuspicious).toBe(false);
+  });
+});
+
+// ─── SUBDOMAIN HIDING (IMPROVEMENT #2) ───────────────────────────
+describe("Subdomain impersonation — NOW CAUGHT", () => {
+  it("catches garanti.evil.com (trusted name in subdomain)", () => {
+    const result = checkTyposquatting("garanti.evil.com");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("garanti.com.tr");
+    expect(result.reason).toBe("subdomain-impersonation");
+  });
+
+  it("catches isbank.phishing.net (trusted name in subdomain)", () => {
+    const result = checkTyposquatting("isbank.phishing.net");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("isbank.com.tr");
+    expect(result.reason).toBe("subdomain-impersonation");
+  });
+
+  it("catches isbenk.evil.com (typosquat in subdomain)", () => {
+    const result = checkTyposquatting("isbenk.evil.com");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("isbank.com.tr");
+    expect(result.reason).toBe("subdomain-typosquat");
+  });
+
+  it("catches paypal.login.evil.com (deep subdomain hiding)", () => {
+    const result = checkTyposquatting("paypal.login.evil.com");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("paypal.com");
+    expect(result.reason).toBe("subdomain-impersonation");
+  });
+});
+
+// ─── SUBSTRING/CONTAINS (IMPROVEMENT #3) ─────────────────────────
+describe("Trusted name as substring — NOW CAUGHT", () => {
+  it("catches securegaranti.com.tr (prefix + trusted name)", () => {
+    const result = checkTyposquatting("securegaranti.com.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("garanti.com.tr");
+    expect(result.reason).toBe("contains-trusted-name");
+  });
+
+  it("catches garantilogin.com (trusted name + suffix)", () => {
+    const result = checkTyposquatting("garantilogin.com");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("garanti.com.tr");
+    expect(result.reason).toBe("contains-trusted-name");
+  });
+
+  it("catches myisbankonline.com (prefix + trusted name + suffix)", () => {
+    const result = checkTyposquatting("myisbankonline.com");
+    expect(result.isSuspicious).toBe(true);
+    // isbank is 6 chars ≥ 5, and "myisbankonline" contains "isbank"
+    expect(result.similarTo).toBe("isbank.com.tr");
+    expect(result.reason).toBe("contains-trusted-name");
+  });
+
+  it("catches hepsiburadaindirim.com (long trusted name embedded)", () => {
+    const result = checkTyposquatting("hepsiburadaindirim.com");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("hepsiburada.com");
+    expect(result.reason).toBe("contains-trusted-name");
+  });
+
+  it("does NOT flag short trusted name substrings to avoid false positives", () => {
+    // "n11" is only 3 chars, so "n11something.com" should NOT trigger
+    // contains check (too many false positives for short names)
+    const result = checkTyposquatting("n11warehouse.com");
+    // Could still be caught by edit-distance if close enough, but
+    // substring check is disabled for names < 5 chars
+    expect(result.reason).not.toBe("contains-trusted-name");
+  });
+});
+
+// ─── UNICODE HOMOGLYPHS (IMPROVEMENT #5) ─────────────────────────
+describe("Unicode homoglyph normalization — NOW CAUGHT", () => {
+  it("normalizeHomoglyphs replaces Cyrillic lookalikes", () => {
+    // "gооgle" with Cyrillic о (U+043E) → "google"
+    expect(normalizeHomoglyphs("g\u043E\u043Egle")).toBe("google");
+  });
+
+  it("normalizeHomoglyphs replaces Greek lookalikes", () => {
+    // "pαypal" with Greek α → "paypal"
+    expect(normalizeHomoglyphs("p\u03B1ypal")).toBe("paypal");
+  });
+
+  it("normalizeHomoglyphs handles Turkish dotless ı", () => {
+    expect(normalizeHomoglyphs("\u0131sbank")).toBe("isbank");
+  });
+
+  it("catches domain with Cyrillic о in name", () => {
+    // "g + Cyrillic-о + Cyrillic-о + gle" looks like "google"
+    const result = checkTyposquatting("g\u043E\u043Egle.com");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("google.com");
+  });
+
+  it("catches Turkish ı substitution in isbank", () => {
+    const result = checkTyposquatting("\u0131sbank.com.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("isbank.com.tr");
+  });
+});
+
+// ─── SEPARATOR STRIPPING (IMPROVEMENT #6) ─────────────────────────
+describe("Separator stripping — hyphens and dots", () => {
+  it("catches i-s-b-a-n-k.com.tr (hyphen-separated letters)", () => {
+    const result = checkTyposquatting("i-s-b-a-n-k.com.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("isbank.com.tr");
+  });
+
+  it("catches is-bank.com.tr (single hyphen)", () => {
+    const result = checkTyposquatting("is-bank.com.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("isbank.com.tr");
+  });
+
+  it("catches pay-pal.com (hyphenated global brand)", () => {
+    const result = checkTyposquatting("pay-pal.com");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("paypal.com");
+  });
+});
+
+// ─── ORIGINAL TESTS STILL PASS ───────────────────────────────────
+describe("Original detection still works (no regressions)", () => {
+  it("catches isbenk.com.tr (1 edit from isbank)", () => {
+    const result = checkTyposquatting("isbenk.com.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("isbank.com.tr");
+    expect(result.reason).toBe("edit-distance");
+  });
+
+  it("catches gogle.com (1 deletion from google)", () => {
+    const result = checkTyposquatting("gogle.com");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("google.com");
+  });
+
+  it("catches paypa1.com (l→1 homoglyph)", () => {
+    const result = checkTyposquatting("paypa1.com");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("paypal.com");
+  });
+
+  it("does NOT flag exact trusted domains", () => {
+    expect(checkTyposquatting("isbank.com.tr").isSuspicious).toBe(false);
+    expect(checkTyposquatting("google.com").isSuspicious).toBe(false);
+    expect(checkTyposquatting("turkiye.gov.tr").isSuspicious).toBe(false);
+  });
+
+  it("does NOT flag completely unrelated domains", () => {
+    expect(checkTyposquatting("randomsite.com").isSuspicious).toBe(false);
+    expect(checkTyposquatting("mywebsite.org").isSuspicious).toBe(false);
+  });
+});
+
+// ─── FULL URL CHECK SCORING ──────────────────────────────────────
+describe("Full URL scoring with improved detection", () => {
+  it("TLD mismatch scores 60 → SUSPICIOUS at medium", () => {
+    const result = checkUrl("https://turkiye.com", "medium");
+    expect(result.score).toBe(60);
+    expect(result.level).toBe(ThreatLevel.SUSPICIOUS);
+    expect(result.reasons[0]).toContain("farkli uzanti");
+  });
+
+  it("TLD mismatch scores 60 → DANGEROUS at high (threshold 50)", () => {
+    const result = checkUrl("https://turkiye.com", "high");
+    expect(result.score).toBe(60);
+    expect(result.level).toBe(ThreatLevel.DANGEROUS);
+  });
+
+  it("substring match (50) + keyword 'secure' (20) = 70 → DANGEROUS", () => {
+    // "securegaranti" contains "garanti" → 50 points
+    // domain contains "secure" keyword → 20 points
+    // Total: 70 → DANGEROUS at medium threshold (70)
+    const result = checkUrl("https://securegaranti.com.tr", "medium");
+    expect(result.score).toBe(70);
+    expect(result.level).toBe(ThreatLevel.DANGEROUS);
+    expect(result.reasons).toHaveLength(2);
+  });
+
+  it("subdomain impersonation scores 65 → SUSPICIOUS at medium", () => {
+    const result = checkUrl("https://garanti.evil.com", "medium");
+    expect(result.score).toBe(65);
+    expect(result.level).toBe(ThreatLevel.SUSPICIOUS);
+  });
+
+  it("classic edit-distance still scores 70 → DANGEROUS at medium", () => {
+    const result = checkUrl("https://isbenk.com.tr", "medium");
+    expect(result.score).toBe(70);
+    expect(result.level).toBe(ThreatLevel.DANGEROUS);
+  });
+});


### PR DESCRIPTION
## Ozet

Mevcut typosquatting tespiti sadece temel Levenshtein mesafesi kontrolu yapiyordu. Bu PR ile tespit motoru **6 yeni yontem** ile guclendirildi. Tum mevcut testler gecmeye devam ediyor (sifir regresyon).

## Yapilan Degisiklikler

### 1. Damerau-Levenshtein Algoritmasi
Standart Levenshtein yerine Damerau-Levenshtein kullanilmaya baslandi. Karakter yer degistirme (transposition) artik **1 islem** olarak sayiliyor (onceki: 2).

| Ornek | Onceki Mesafe | Yeni Mesafe |
|-------|--------------|-------------|
| `garanti` → `garanit` | 2 | 1 |
| `paypal` → `paypla` | 2 | 1 |

### 2. TLD Uyusmazligi Tespiti (Yeni)
Ayni isim farkli uzanti kullanan sahte siteleri yakalamak icin eklendi.

| Saldiri | Benzetilen Site | Sonuc |
|---------|----------------|-------|
| `turkiye.com` | `turkiye.gov.tr` | ⚠️ Suppheli (60 puan) |
| `isbank.com` | `isbank.com.tr` | ⚠️ Suppheli (60 puan) |
| `garanti.net` | `garanti.com.tr` | ⚠️ Suppheli (60 puan) |

### 3. Alt Alan Adi (Subdomain) Taklitciligi Tespiti (Yeni)
Guvenilir isimlerin alt alan adlarinda saklanmasini tespit eder.

| Saldiri | Benzetilen Site | Sonuc |
|---------|----------------|-------|
| `garanti.evil.com` | `garanti.com.tr` | ⚠️ Suppheli (65 puan) |
| `isbank.phishing.net` | `isbank.com.tr` | ⚠️ Suppheli (65 puan) |
| `isbenk.evil.com` | `isbank.com.tr` | ⚠️ Suppheli (55 puan) |

### 4. Alt Dize (Substring) Kontrolu (Yeni)
Guvenilir isimlerin (>=5 karakter) uzun domainlere gomulmesini tespit eder.

| Saldiri | Benzetilen Site | Sonuc |
|---------|----------------|-------|
| `securegaranti.com.tr` | `garanti.com.tr` | ⚠️ Suppheli (50 puan) |
| `hepsiburadaindirim.com` | `hepsiburada.com` | ⚠️ Suppheli (50 puan) |
| `myisbankonline.com` | `isbank.com.tr` | ⚠️ Suppheli (50 puan) |

### 5. Unicode Homoglif Normalizasyonu (Yeni)
Kiril, Yunan ve Turkce benzer karakterleri Latin karsiliklarina donusturur.

| Karakter | Unicode | Donusturulur |
|----------|---------|-------------|
| Kiril а | U+0430 | → a |
| Kiril о | U+043E | → o |
| Kiril с | U+0441 | → c |
| Yunan α | U+03B1 | → a |
| Turkce ı | U+0131 | → i |

**Ornekler:** `gооgle.com` (Kiril о), `ısbank.com.tr` (Turkce ı) artik yakalaniyor.

### 6. Ayirici Karakter Temizleme (Yeni)
Tire (`-`), nokta (`.`) ve alt cizgi (`_`) karakterleri karsilastirma oncesi temizlenir.

| Saldiri | Temizlenmis Hali | Sonuc |
|---------|-----------------|-------|
| `i-s-b-a-n-k.com.tr` | `isbank` | ✅ Yakalandi |
| `pay-pal.com` | `paypal` | ✅ Yakalandi |

## Puanlama Sistemi

Tespit turune gore farkli puanlar ataniyor:

| Tespit Turu | Puan | Aciklama |
|-------------|------|----------|
| Edit-distance (klasik typosquat) | 70 | En yuksek guven — cok benzer isim |
| Subdomain taklitciligi (birebir) | 65 | Guvenilir isim alt alanda saklaniyor |
| TLD uyusmazligi | 60 | Ayni isim farkli uzanti |
| Subdomain typosquat | 55 | Alt alanda benzer isim |
| Guvenilir isim icerme | 50 | Uzun domainde gomulu isim |

## Test Plani

- [x] Mevcut 28 url-checker testi gecmeye devam ediyor (sifir regresyon)
- [x] 36 yeni test eklendi (`tests/detector/typosquatting-deep.test.ts`)
- [x] Tam test suite: **121 test basarili** (9 dosya)
- [x] Damerau-Levenshtein transposition testleri
- [x] TLD uyusmazligi testleri (turkiye.com, isbank.com, garanti.net)
- [x] Subdomain taklitciligi testleri (garanti.evil.com, paypal.login.evil.com)
- [x] Substring tespiti testleri (securegaranti, hepsiburadaindirim)
- [x] Unicode homoglif testleri (Kiril, Yunan, Turkce ı)
- [x] Ayirici karakter testleri (i-s-b-a-n-k, pay-pal)
- [x] False positive kontrolleri (rastgele domainler, guvenilir domainler)

## Degisiklik Ozeti

| Dosya | Degisiklik |
|-------|-----------|
| `src/detector/url-checker.ts` | +113 satir, -13 satir |
| `tests/detector/typosquatting-deep.test.ts` | Yeni dosya, 36 test |

## Onceki Durumda Yakalanamayanlar → Simdi Yakalananlar

```
turkiye.com                    ❌ → ✅ (TLD uyusmazligi)
garanti.evil.com               ❌ → ✅ (subdomain taklitciligi)
securegaranti.com.tr           ❌ → ✅ (substring kontrolu)
gооgle.com (Kiril)             ❌ → ✅ (homoglif normalizasyonu)
ısbank.com.tr (Turkce ı)       ❌ → ✅ (homoglif normalizasyonu)
i-s-b-a-n-k.com.tr             ❌ → ✅ (ayirici temizleme)
garanit.com.tr (yer degistirme) ⚠️ → ✅ (Damerau ile mesafe 1)
```