### PR TITLE
add security dashboard & site breach check modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ dist-firefox/
 CLAUDE.md
 .claude/
 .planning/
+playwright-report
+test-results
+docs
+.idea

--- a/e2e/fixtures/extension.ts
+++ b/e2e/fixtures/extension.ts
@@ -1,5 +1,9 @@
 import { test as base, chromium, type BrowserContext } from "@playwright/test";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export const test = base.extend<{
   context: BrowserContext;

--- a/e2e/fixtures/extension.ts
+++ b/e2e/fixtures/extension.ts
@@ -1,0 +1,33 @@
+import { test as base, chromium, type BrowserContext } from "@playwright/test";
+import path from "path";
+
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionId: string;
+}>({
+  // eslint-disable-next-line no-empty-pattern
+  context: async ({}, use) => {
+    const extensionPath = path.resolve(__dirname, "../../dist");
+    const context = await chromium.launchPersistentContext("", {
+      headless: false,
+      args: [
+        "--disable-extensions-except=" + extensionPath,
+        "--load-extension=" + extensionPath,
+        "--no-first-run",
+        "--disable-gpu",
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+  extensionId: async ({ context }, use) => {
+    let serviceWorker = context.serviceWorkers()[0];
+    if (!serviceWorker) {
+      serviceWorker = await context.waitForEvent("serviceworker");
+    }
+    const extensionId = serviceWorker.url().split("/")[2];
+    await use(extensionId);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/e2e/helpers/extension-page.ts
+++ b/e2e/helpers/extension-page.ts
@@ -1,0 +1,24 @@
+import type { BrowserContext, Page } from "@playwright/test";
+
+export async function openPopup(context: BrowserContext, extensionId: string): Promise<Page> {
+  const popupUrl = "chrome-extension://" + extensionId + "/popup.html";
+  const page = await context.newPage();
+  await page.goto(popupUrl);
+  await page.waitForLoadState("domcontentloaded");
+  return page;
+}
+
+export async function openOptionsPage(context: BrowserContext, extensionId: string): Promise<Page> {
+  const optionsUrl = "chrome-extension://" + extensionId + "/options.html";
+  const page = await context.newPage();
+  await page.goto(optionsUrl);
+  await page.waitForLoadState("domcontentloaded");
+  return page;
+}
+
+export async function navigateToSite(context: BrowserContext, url: string): Promise<Page> {
+  const page = await context.newPage();
+  await page.goto(url);
+  await page.waitForLoadState("domcontentloaded");
+  return page;
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./specs",
+  timeout: 60000,
+  retries: 1,
+  workers: 1,
+  reporter: [["html", { open: "never" }], ["list"]],
+  use: {
+    headless: false,
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        browserName: "chromium",
+      },
+    },
+  ],
+});

--- a/e2e/specs/breach-check.spec.ts
+++ b/e2e/specs/breach-check.spec.ts
@@ -2,7 +2,10 @@ import { test, expect } from "../fixtures/extension";
 import { openPopup, navigateToSite } from "../helpers/extension-page";
 
 test.describe("Breach Check — Happy Path", () => {
-  test("should show breach badge in popup for known breached site", async ({ context, extensionId }) => {
+  // The popup reads the active tab via chrome.tabs.query({ active: true, currentWindow: true }),
+  // but opening the popup as a new page makes it the active tab instead of the linkedin page.
+  // This means the breach badge cannot show the linkedin domain in this testing setup.
+  test.fixme("should show breach badge in popup for known breached site", async ({ context, extensionId }) => {
     const page = await navigateToSite(context, "https://www.linkedin.com");
     await page.waitForTimeout(2000);
 
@@ -32,7 +35,9 @@ test.describe("Breach Check — Happy Path", () => {
     await page.close();
   });
 
-  test("should show breach details with data types", async ({ context, extensionId }) => {
+  // Same active-tab issue as "should show breach badge" test above.
+  // The popup cannot detect the linkedin tab as active when opened as a separate page.
+  test.fixme("should show breach details with data types", async ({ context, extensionId }) => {
     const page = await navigateToSite(context, "https://www.linkedin.com");
     await page.waitForTimeout(2000);
 
@@ -57,7 +62,7 @@ test.describe("Breach Check — Negative Scenarios", () => {
     await page.waitForTimeout(500);
 
     const popup = await openPopup(context, extensionId);
-    await expect(popup.getByText("Alparslan")).toBeVisible();
+    await expect(popup.getByText("Alparslan").first()).toBeVisible();
     await popup.close();
     await page.close();
   });

--- a/e2e/specs/breach-check.spec.ts
+++ b/e2e/specs/breach-check.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "../fixtures/extension";
+import { openPopup, navigateToSite } from "../helpers/extension-page";
+
+test.describe("Breach Check — Happy Path", () => {
+  test("should show breach badge in popup for known breached site", async ({ context, extensionId }) => {
+    const page = await navigateToSite(context, "https://www.linkedin.com");
+    await page.waitForTimeout(2000);
+
+    const popup = await openPopup(context, extensionId);
+    await expect(popup.getByText(/veri sizintisi/)).toBeVisible({ timeout: 5000 });
+    await popup.close();
+    await page.close();
+  });
+
+  test("should show breach info banner on page of breached site", async ({ context, extensionId }) => {
+    const page = await navigateToSite(context, "https://www.linkedin.com");
+    await page.waitForTimeout(2000);
+
+    const bannerHost = page.locator("#alparslan-breach-host");
+    await expect(bannerHost).toBeVisible({ timeout: 5000 });
+    await page.close();
+  });
+
+  test("should not show breach badge for non-breached site", async ({ context, extensionId }) => {
+    const page = await navigateToSite(context, "https://example.com");
+    await page.waitForTimeout(1500);
+
+    const popup = await openPopup(context, extensionId);
+    const breachCount = await popup.getByText(/veri sizintisi/).count();
+    expect(breachCount).toBe(0);
+    await popup.close();
+    await page.close();
+  });
+
+  test("should show breach details with data types", async ({ context, extensionId }) => {
+    const page = await navigateToSite(context, "https://www.linkedin.com");
+    await page.waitForTimeout(2000);
+
+    const popup = await openPopup(context, extensionId);
+    await expect(popup.getByText(/email/)).toBeVisible({ timeout: 5000 });
+    await popup.close();
+    await page.close();
+  });
+});
+
+test.describe("Breach Check — Negative Scenarios", () => {
+  test("negative: should not show breach banner on extension pages", async ({ context, extensionId }) => {
+    const popup = await openPopup(context, extensionId);
+    const breachCount = await popup.getByText(/veri sizintisi/).count();
+    expect(breachCount).toBe(0);
+    await popup.close();
+  });
+
+  test("negative: should not crash on about:blank", async ({ context, extensionId }) => {
+    const page = await context.newPage();
+    await page.goto("about:blank");
+    await page.waitForTimeout(500);
+
+    const popup = await openPopup(context, extensionId);
+    await expect(popup.getByText("Alparslan")).toBeVisible();
+    await popup.close();
+    await page.close();
+  });
+
+  test("negative: breach banner host should be removable from DOM", async ({ context, extensionId }) => {
+    const page = await navigateToSite(context, "https://www.linkedin.com");
+    await page.waitForTimeout(2000);
+
+    const bannerHost = page.locator("#alparslan-breach-host");
+    if (await bannerHost.isVisible()) {
+      await page.evaluate(() => {
+        const host = document.getElementById("alparslan-breach-host");
+        host?.remove();
+      });
+      await expect(bannerHost).not.toBeVisible();
+    }
+    await page.close();
+  });
+});

--- a/e2e/specs/dashboard.spec.ts
+++ b/e2e/specs/dashboard.spec.ts
@@ -12,10 +12,12 @@ test.describe("Dashboard Score — Happy Path", () => {
   test("should show score breakdown categories", async ({ context, extensionId }) => {
     const popup = await openPopup(context, extensionId);
     await popup.getByText("Skor").click();
-    await expect(popup.getByText("HTTPS")).toBeVisible();
-    await expect(popup.getByText("Tehdit")).toBeVisible();
+    // Wait for dashboard to load (loading state shows "Yukleniyor...")
+    await expect(popup.getByText("Haftalik Guvenlik Skoru")).toBeVisible({ timeout: 10000 });
+    await expect(popup.getByText("HTTPS").first()).toBeVisible();
+    await expect(popup.getByText("Tehdit").first()).toBeVisible();
     await expect(popup.getByText("Aktivite")).toBeVisible();
-    await expect(popup.getByText("Tracker")).toBeVisible();
+    await expect(popup.getByText("Tracker").first()).toBeVisible();
     await popup.close();
   });
 

--- a/e2e/specs/dashboard.spec.ts
+++ b/e2e/specs/dashboard.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "../fixtures/extension";
+import { openPopup, navigateToSite, openOptionsPage } from "../helpers/extension-page";
+
+test.describe("Dashboard Score — Happy Path", () => {
+  test("should show score with no browsing activity", async ({ context, extensionId }) => {
+    const popup = await openPopup(context, extensionId);
+    await popup.getByText("Skor").click();
+    await expect(popup.getByText("Haftalik Guvenlik Skoru")).toBeVisible();
+    await popup.close();
+  });
+
+  test("should show score breakdown categories", async ({ context, extensionId }) => {
+    const popup = await openPopup(context, extensionId);
+    await popup.getByText("Skor").click();
+    await expect(popup.getByText("HTTPS")).toBeVisible();
+    await expect(popup.getByText("Tehdit")).toBeVisible();
+    await expect(popup.getByText("Aktivite")).toBeVisible();
+    await expect(popup.getByText("Tracker")).toBeVisible();
+    await popup.close();
+  });
+
+  test("should show tips for new user", async ({ context, extensionId }) => {
+    const popup = await openPopup(context, extensionId);
+    await popup.getByText("Skor").click();
+    await expect(popup.getByText("Oneriler")).toBeVisible();
+    await popup.close();
+  });
+
+  test("should update score after browsing HTTPS sites", async ({ context, extensionId }) => {
+    const page1 = await navigateToSite(context, "https://example.com");
+    await page1.waitForTimeout(1000);
+    await page1.close();
+
+    const page2 = await navigateToSite(context, "https://www.google.com");
+    await page2.waitForTimeout(1000);
+    await page2.close();
+
+    const popup = await openPopup(context, extensionId);
+    await popup.getByText("Skor").click();
+    await popup.waitForTimeout(500);
+
+    const scoreElement = popup.locator('[style*="font-size: 28px"]');
+    const scoreText = await scoreElement.textContent();
+    const score = parseInt(scoreText || "0", 10);
+    expect(score).toBeGreaterThan(0);
+    await popup.close();
+  });
+
+  test("should show options page header", async ({ context, extensionId }) => {
+    const options = await openOptionsPage(context, extensionId);
+    await expect(options.getByText("Alparslan Ayarlar")).toBeVisible();
+    await options.close();
+  });
+});
+
+test.describe("Dashboard Score — Negative Scenarios", () => {
+  test("negative: score should not exceed 100", async ({ context, extensionId }) => {
+    for (let i = 0; i < 5; i++) {
+      const page = await navigateToSite(context, "https://example.com");
+      await page.waitForTimeout(300);
+      await page.close();
+    }
+
+    const popup = await openPopup(context, extensionId);
+    await popup.getByText("Skor").click();
+    await popup.waitForTimeout(500);
+    const scoreElement = popup.locator('[style*="font-size: 28px"]');
+    const scoreText = await scoreElement.textContent();
+    const score = parseInt(scoreText || "0", 10);
+    expect(score).toBeLessThanOrEqual(100);
+    expect(score).toBeGreaterThanOrEqual(0);
+    await popup.close();
+  });
+
+  test("negative: dashboard should handle extension disabled state", async ({ context, extensionId }) => {
+    const popup = await openPopup(context, extensionId);
+    await popup.getByText("Aktif").click();
+    await popup.waitForTimeout(300);
+    await popup.getByText("Skor").click();
+    await expect(popup.getByText("Haftalik Guvenlik Skoru")).toBeVisible();
+    await popup.close();
+  });
+});

--- a/e2e/specs/options-dashboard.spec.ts
+++ b/e2e/specs/options-dashboard.spec.ts
@@ -26,8 +26,12 @@ test.describe("Options Page — Happy Path", () => {
 
   test("should allow adding to whitelist", async ({ context, extensionId }) => {
     const options = await openOptionsPage(context, extensionId);
-    await options.getByPlaceholder("ornek: example.com").fill("test-safe-site.com");
-    await options.getByText("Ekle").click();
+    // Wait for the page to fully render
+    await expect(options.getByRole("heading", { name: "Beyaz Liste" })).toBeVisible({ timeout: 5000 });
+    const input = options.getByPlaceholder("ornek: example.com");
+    await expect(input).toBeVisible();
+    await input.fill("test-safe-site.com");
+    await options.getByRole("button", { name: "Ekle" }).click();
     await expect(options.getByText("test-safe-site.com")).toBeVisible();
     await options.close();
   });
@@ -47,11 +51,14 @@ test.describe("Options Page — Happy Path", () => {
 test.describe("Options Page — Negative Scenarios", () => {
   test("negative: should not add empty domain to whitelist", async ({ context, extensionId }) => {
     const options = await openOptionsPage(context, extensionId);
-    const beforeText = await options.getByText("Beyaz liste bos").isVisible().catch(() => false);
-    await options.getByText("Ekle").click();
-    if (beforeText) {
-      await expect(options.getByText("Beyaz liste bos")).toBeVisible();
-    }
+    // Wait for the page to fully render
+    await expect(options.getByRole("heading", { name: "Beyaz Liste" })).toBeVisible({ timeout: 5000 });
+    // Verify whitelist is empty initially
+    await expect(options.getByText("Beyaz liste bos")).toBeVisible();
+    // Click Ekle with empty input
+    await options.getByRole("button", { name: "Ekle" }).click();
+    // Whitelist should still be empty
+    await expect(options.getByText("Beyaz liste bos")).toBeVisible();
     await options.close();
   });
 

--- a/e2e/specs/options-dashboard.spec.ts
+++ b/e2e/specs/options-dashboard.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "../fixtures/extension";
+import { openOptionsPage, navigateToSite } from "../helpers/extension-page";
+
+test.describe("Options Page — Happy Path", () => {
+  test("should render options page header", async ({ context, extensionId }) => {
+    const options = await openOptionsPage(context, extensionId);
+    await expect(options.getByText("Alparslan Ayarlar")).toBeVisible();
+    await options.close();
+  });
+
+  test("should show protection level settings", async ({ context, extensionId }) => {
+    const options = await openOptionsPage(context, extensionId);
+    await expect(options.getByText("Koruma Seviyesi")).toBeVisible();
+    await expect(options.getByText("Dusuk")).toBeVisible();
+    await expect(options.getByText("Orta")).toBeVisible();
+    await expect(options.getByText("Yuksek")).toBeVisible();
+    await options.close();
+  });
+
+  test("should allow changing protection level", async ({ context, extensionId }) => {
+    const options = await openOptionsPage(context, extensionId);
+    await options.getByText("Yuksek").click();
+    await expect(options.getByText("Ayarlar kaydedildi")).toBeVisible({ timeout: 3000 });
+    await options.close();
+  });
+
+  test("should allow adding to whitelist", async ({ context, extensionId }) => {
+    const options = await openOptionsPage(context, extensionId);
+    await options.getByPlaceholder("ornek: example.com").fill("test-safe-site.com");
+    await options.getByText("Ekle").click();
+    await expect(options.getByText("test-safe-site.com")).toBeVisible();
+    await options.close();
+  });
+
+  test("should show security summary after browsing", async ({ context, extensionId }) => {
+    const page = await navigateToSite(context, "https://example.com");
+    await page.waitForTimeout(1000);
+    await page.close();
+
+    const options = await openOptionsPage(context, extensionId);
+    await options.waitForTimeout(1000);
+    await expect(options.getByText("Alparslan Ayarlar")).toBeVisible();
+    await options.close();
+  });
+});
+
+test.describe("Options Page — Negative Scenarios", () => {
+  test("negative: should not add empty domain to whitelist", async ({ context, extensionId }) => {
+    const options = await openOptionsPage(context, extensionId);
+    const beforeText = await options.getByText("Beyaz liste bos").isVisible().catch(() => false);
+    await options.getByText("Ekle").click();
+    if (beforeText) {
+      await expect(options.getByText("Beyaz liste bos")).toBeVisible();
+    }
+    await options.close();
+  });
+
+  test("negative: should handle data clear gracefully", async ({ context, extensionId }) => {
+    const options = await openOptionsPage(context, extensionId);
+    await options.getByText("Tum Verileri Temizle").click();
+    await expect(options.getByText("Veriler temizlendi")).toBeVisible({ timeout: 3000 });
+    await expect(options.getByText("Koruma Seviyesi")).toBeVisible();
+    await options.close();
+  });
+});

--- a/e2e/specs/popup-navigation.spec.ts
+++ b/e2e/specs/popup-navigation.spec.ts
@@ -4,7 +4,7 @@ import { openPopup } from "../helpers/extension-page";
 test.describe("Popup Navigation", () => {
   test("should show header with Alparslan branding", async ({ context, extensionId }) => {
     const popup = await openPopup(context, extensionId);
-    await expect(popup.getByText("Alparslan")).toBeVisible();
+    await expect(popup.getByText("Alparslan").first()).toBeVisible();
     await popup.close();
   });
 
@@ -46,7 +46,9 @@ test.describe("Popup Navigation", () => {
 
   test("negative: should show disabled state when toggled off", async ({ context, extensionId }) => {
     const popup = await openPopup(context, extensionId);
-    await popup.getByText("Aktif").click();
+    // Click the toggle track div (width: 36px, inside the header label)
+    const toggleTrack = popup.locator('label div[style*="width: 36px"]');
+    await toggleTrack.click();
     await expect(popup.getByText("Pasif")).toBeVisible();
     await expect(popup.getByText("Koruma Kapali")).toBeVisible();
     await popup.close();

--- a/e2e/specs/popup-navigation.spec.ts
+++ b/e2e/specs/popup-navigation.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "../fixtures/extension";
+import { openPopup } from "../helpers/extension-page";
+
+test.describe("Popup Navigation", () => {
+  test("should show header with Alparslan branding", async ({ context, extensionId }) => {
+    const popup = await openPopup(context, extensionId);
+    await expect(popup.getByText("Alparslan")).toBeVisible();
+    await popup.close();
+  });
+
+  test("should show Durum and Skor tabs", async ({ context, extensionId }) => {
+    const popup = await openPopup(context, extensionId);
+    await expect(popup.getByText("Durum")).toBeVisible();
+    await expect(popup.getByText("Skor")).toBeVisible();
+    await popup.close();
+  });
+
+  test("should default to Durum tab with stats visible", async ({ context, extensionId }) => {
+    const popup = await openPopup(context, extensionId);
+    await expect(popup.getByText("Kontrol")).toBeVisible();
+    await expect(popup.getByText("Tehdit")).toBeVisible();
+    await popup.close();
+  });
+
+  test("should switch to Skor tab when clicked", async ({ context, extensionId }) => {
+    const popup = await openPopup(context, extensionId);
+    await popup.getByText("Skor").click();
+    await expect(popup.getByText("Haftalik Guvenlik Skoru")).toBeVisible();
+    await popup.close();
+  });
+
+  test("should switch back to Durum tab", async ({ context, extensionId }) => {
+    const popup = await openPopup(context, extensionId);
+    await popup.getByText("Skor").click();
+    await expect(popup.getByText("Haftalik Guvenlik Skoru")).toBeVisible();
+    await popup.getByText("Durum").click();
+    await expect(popup.getByText("Kontrol")).toBeVisible();
+    await popup.close();
+  });
+
+  test("should show toggle switch in header", async ({ context, extensionId }) => {
+    const popup = await openPopup(context, extensionId);
+    await expect(popup.getByText("Aktif")).toBeVisible();
+    await popup.close();
+  });
+
+  test("negative: should show disabled state when toggled off", async ({ context, extensionId }) => {
+    const popup = await openPopup(context, extensionId);
+    await popup.getByText("Aktif").click();
+    await expect(popup.getByText("Pasif")).toBeVisible();
+    await expect(popup.getByText("Koruma Kapali")).toBeVisible();
+    await popup.close();
+  });
+});

--- a/lists/breached-sites.json
+++ b/lists/breached-sites.json
@@ -1,0 +1,25 @@
+{
+  "version": "2026-03-29",
+  "breaches": [
+    { "domain": "linkedin.com", "name": "LinkedIn 2021", "date": "2021-06", "accountsAffected": 700000000, "dataTypes": ["email", "isim", "telefon"] },
+    { "domain": "facebook.com", "name": "Facebook 2021", "date": "2021-04", "accountsAffected": 533000000, "dataTypes": ["email", "telefon", "konum"] },
+    { "domain": "twitter.com", "name": "Twitter 2023", "date": "2023-01", "accountsAffected": 200000000, "dataTypes": ["email"] },
+    { "domain": "adobe.com", "name": "Adobe 2013", "date": "2013-10", "accountsAffected": 153000000, "dataTypes": ["email", "sifre", "kredi karti"] },
+    { "domain": "canva.com", "name": "Canva 2019", "date": "2019-05", "accountsAffected": 137000000, "dataTypes": ["email", "isim", "sifre"] },
+    { "domain": "myspace.com", "name": "MySpace 2016", "date": "2016-05", "accountsAffected": 360000000, "dataTypes": ["email", "sifre"] },
+    { "domain": "dropbox.com", "name": "Dropbox 2012", "date": "2012-07", "accountsAffected": 68000000, "dataTypes": ["email", "sifre"] },
+    { "domain": "tumblr.com", "name": "Tumblr 2013", "date": "2013-02", "accountsAffected": 65000000, "dataTypes": ["email", "sifre"] },
+    { "domain": "yahoo.com", "name": "Yahoo 2013-2014", "date": "2014-12", "accountsAffected": 3000000000, "dataTypes": ["email", "sifre", "guvenlik sorulari"] },
+    { "domain": "zynga.com", "name": "Zynga 2019", "date": "2019-09", "accountsAffected": 170000000, "dataTypes": ["email", "sifre", "kullanici adi"] },
+    { "domain": "last.fm", "name": "Last.fm 2012", "date": "2012-03", "accountsAffected": 43000000, "dataTypes": ["email", "sifre"] },
+    { "domain": "dubsmash.com", "name": "Dubsmash 2018", "date": "2018-12", "accountsAffected": 162000000, "dataTypes": ["email", "sifre"] },
+    { "domain": "spotify.com", "name": "Spotify 2020", "date": "2020-11", "accountsAffected": 350000, "dataTypes": ["email", "sifre"] },
+    { "domain": "yemeksepeti.com", "name": "Yemeksepeti 2021", "date": "2021-03", "accountsAffected": 21000000, "dataTypes": ["email", "telefon", "adres"] },
+    { "domain": "trendyol.com", "name": "Trendyol (iddia)", "date": "2022-06", "accountsAffected": 0, "dataTypes": ["email", "adres"] },
+    { "domain": "twitch.tv", "name": "Twitch 2021", "date": "2021-10", "accountsAffected": 0, "dataTypes": ["kaynak kodu", "kazanc verileri"] },
+    { "domain": "t-mobile.com", "name": "T-Mobile 2021", "date": "2021-08", "accountsAffected": 77000000, "dataTypes": ["isim", "SSN", "ehliyet"] },
+    { "domain": "marriott.com", "name": "Marriott 2018", "date": "2018-11", "accountsAffected": 500000000, "dataTypes": ["isim", "pasaport", "kredi karti"] },
+    { "domain": "epicgames.com", "name": "Epic Games 2019", "date": "2019-01", "accountsAffected": 0, "dataTypes": ["email", "sifre"] },
+    { "domain": "zoom.us", "name": "Zoom 2020", "date": "2020-04", "accountsAffected": 500000, "dataTypes": ["email", "sifre"] }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/chrome": "^0.0.268",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -20,12 +22,20 @@
         "@vitejs/plugin-react": "^4.3.1",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
+        "happy-dom": "^20.8.9",
         "jsdom": "^29.0.1",
         "prettier": "^3.3.3",
         "typescript": "^5.5.3",
         "vite": "^5.3.4",
         "vitest": "^2.0.3"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.0.1",
@@ -340,6 +350,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1546,6 +1566,90 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1633,6 +1737,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1659,6 +1773,23 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2068,6 +2199,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -2323,6 +2464,13 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2386,6 +2534,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2411,6 +2569,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.326",
@@ -2970,6 +3136,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/happy-dom": {
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3028,6 +3235,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -3299,6 +3516,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3338,6 +3566,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3614,6 +3852,36 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3670,6 +3938,14 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3678,6 +3954,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-from-string": {
@@ -3909,6 +4199,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4114,6 +4417,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -4402,6 +4712,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/chrome": "^0.0.268",
@@ -1207,6 +1208,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3795,6 +3812,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -14,13 +14,18 @@
     "lint": "eslint src/",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\"",
     "package": "npm run build && cd dist && zip -r ../alparslan-chrome.zip . && cd ..",
-    "package:firefox": "npm run build:firefox && cd dist-firefox && zip -r ../alparslan-firefox.zip . && cd .."
+    "package:firefox": "npm run build:firefox && cd dist-firefox && zip -r ../alparslan-firefox.zip . && cd ..",
+    "test:e2e": "npx playwright test --config e2e/playwright.config.ts",
+    "test:e2e:headed": "npx playwright test --config e2e/playwright.config.ts --headed",
+    "test:e2e:debug": "npx playwright test --config e2e/playwright.config.ts --debug",
+    "test:e2e:report": "npx playwright show-report"
   },
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/chrome": "^0.0.268",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/chrome": "^0.0.268",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
@@ -29,6 +31,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
+    "happy-dom": "^20.8.9",
     "jsdom": "^29.0.1",
     "prettier": "^3.3.3",
     "typescript": "^5.5.3",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,6 +4,11 @@ import { type Message, type ExtensionSettings, type ExtensionStats, type SiteRep
 import type { PageAnalysisResult } from "@/detector/page-analyzer";
 import { checkUrl, loadBlocklist, extractDomain } from "@/detector/url-checker";
 import { fetchRemoteBlocklist, submitReport, scheduleListUpdates } from "@/blocklist/updater";
+import { checkBreach, loadBreachDatabase as loadBreachDB } from "@/breach/checker";
+import { fetchRemoteBreachDatabase } from "@/breach/updater";
+import { collectCurrentWeekMetrics, collectPreviousWeekMetrics, recordPageProtocol, recordThreatVisit } from "@/dashboard/metrics-collector";
+import { calculateScore } from "@/dashboard/score-calculator";
+import type { BreachEntry } from "@/breach/types";
 
 interface ExtensionState {
   enabled: boolean;
@@ -74,6 +79,20 @@ chrome.runtime.onInstalled.addListener(() => {
 
   // Try an immediate remote fetch (merges with built-in list)
   fetchRemoteBlocklist();
+
+  // Load built-in breach database
+  fetch(chrome.runtime.getURL("lists/breached-sites.json"))
+    .then((r) => r.json())
+    .then((data: { breaches: BreachEntry[] }) => {
+      loadBreachDB(data.breaches);
+      console.warn("[Alparslan] Loaded " + String(data.breaches.length) + " breach entries");
+    })
+    .catch(() => {
+      console.warn("[Alparslan] Could not load breach database");
+    });
+
+  // Try immediate remote breach fetch
+  fetchRemoteBreachDatabase();
 });
 
 chrome.runtime.onMessage.addListener(
@@ -102,6 +121,7 @@ chrome.runtime.onMessage.addListener(
       const result = checkUrl(message.url as string, state.settings.protectionLevel);
       if (result.level === "DANGEROUS" || result.level === "SUSPICIOUS") {
         state.stats.threatsBlocked++;
+        recordThreatVisit(result.level);
       }
       persistStats();
       addHistoryEntry(url, result.level, result.score);
@@ -211,6 +231,31 @@ chrome.runtime.onMessage.addListener(
       return true;
     }
 
+    if (message.type === "CHECK_BREACH") {
+      const domain = message.domain as string;
+      const result = checkBreach(domain);
+      sendResponse(result);
+      return true;
+    }
+
+    if (message.type === "GET_DASHBOARD_SCORE") {
+      (async () => {
+        const currentWeek = await collectCurrentWeekMetrics();
+        const previousWeek = await collectPreviousWeekMetrics();
+        const dashboard = calculateScore(currentWeek);
+        dashboard.previousWeek = previousWeek;
+        sendResponse({ dashboard });
+      })();
+      return true;
+    }
+
+    if (message.type === "RECORD_PROTOCOL") {
+      const url = message.url as string;
+      recordPageProtocol(url);
+      sendResponse({ ok: true });
+      return true;
+    }
+
     return false;
   },
 );
@@ -231,6 +276,7 @@ function updateBadge(tabId: number, level: string): void {
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, _tab) => {
   if (changeInfo.url && state.enabled) {
     const result = checkUrl(changeInfo.url, state.settings.protectionLevel);
+    recordPageProtocol(changeInfo.url);
 
     updateBadge(tabId, result.level);
 

--- a/src/breach/checker.ts
+++ b/src/breach/checker.ts
@@ -1,0 +1,41 @@
+import type { BreachEntry, BreachCheckResult } from "./types";
+
+let breachDatabase: BreachEntry[] = [];
+
+export function loadBreachDatabase(entries: BreachEntry[], replace = true): void {
+  if (replace) {
+    breachDatabase = entries.map((e) => ({ ...e, domain: e.domain.toLowerCase() }));
+  } else {
+    for (const entry of entries) {
+      breachDatabase.push({ ...entry, domain: entry.domain.toLowerCase() });
+    }
+  }
+}
+
+export function getBreachDatabaseSize(): number {
+  return breachDatabase.length;
+}
+
+function extractRootForBreach(hostname: string): string {
+  const parts = hostname.toLowerCase().split(".");
+  if (parts.length <= 2) return hostname.toLowerCase();
+  const sld = parts[parts.length - 2];
+  if (["com", "gov", "org", "edu", "net"].includes(sld) && parts.length >= 3) {
+    return parts.slice(-3).join(".");
+  }
+  return parts.slice(-2).join(".");
+}
+
+export function checkBreach(hostname: string): BreachCheckResult {
+  const normalizedHost = hostname.toLowerCase();
+  const rootDomain = extractRootForBreach(normalizedHost);
+
+  const matches = breachDatabase.filter(
+    (entry) => entry.domain === rootDomain || entry.domain === normalizedHost,
+  );
+
+  return {
+    isBreached: matches.length > 0,
+    breaches: matches,
+  };
+}

--- a/src/breach/types.ts
+++ b/src/breach/types.ts
@@ -1,0 +1,12 @@
+export interface BreachEntry {
+  domain: string;
+  name: string;
+  date: string;
+  accountsAffected: number;
+  dataTypes: string[];
+}
+
+export interface BreachCheckResult {
+  isBreached: boolean;
+  breaches: BreachEntry[];
+}

--- a/src/breach/updater.ts
+++ b/src/breach/updater.ts
@@ -1,0 +1,42 @@
+import type { BreachEntry } from "./types";
+import { loadBreachDatabase } from "./checker";
+
+let breachApiUrl = "https://api.dijitalsavunma.org/v1/breaches";
+
+export function setBreachApiUrl(url: string): void {
+  breachApiUrl = url;
+}
+
+export function getBreachApiUrl(): string {
+  return breachApiUrl;
+}
+
+export async function fetchRemoteBreachDatabase(): Promise<number> {
+  try {
+    const response = await fetch(breachApiUrl, {
+      headers: { Accept: "application/json" },
+    });
+
+    if (!response.ok) {
+      console.warn("[Alparslan] Breach DB update failed: HTTP " + String(response.status));
+      return -1;
+    }
+
+    const data = await response.json();
+
+    if (!Array.isArray(data.breaches)) {
+      return 0;
+    }
+
+    const entries: BreachEntry[] = data.breaches;
+    if (entries.length > 0) {
+      loadBreachDatabase(entries, false);
+      console.warn("[Alparslan] Breach DB updated: " + String(entries.length) + " entries");
+    }
+
+    return entries.length;
+  } catch (err) {
+    console.warn("[Alparslan] Breach DB update error:", err);
+    return -1;
+  }
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -3,6 +3,7 @@
 import { analyzePage } from "@/detector/page-analyzer";
 
 const BANNER_HOST_ID = "alparslan-warning-host";
+const BREACH_BANNER_HOST_ID = "alparslan-breach-host";
 
 interface WarningMessage {
   type: "SHOW_WARNING";
@@ -83,6 +84,58 @@ function escapeHtml(text: string): string {
   return div.innerHTML;
 }
 
+function createBreachInfoBanner(reason: string): void {
+  const existing = document.getElementById(BREACH_BANNER_HOST_ID);
+  if (existing) existing.remove();
+
+  const host = document.createElement("div");
+  host.id = BREACH_BANNER_HOST_ID;
+  host.style.cssText = "all: initial; position: fixed; bottom: 0; left: 0; width: 100%; z-index: 2147483647;";
+
+  const shadow = host.attachShadow({ mode: "closed" });
+
+  const style = document.createElement("style");
+  style.textContent = [
+    ".breach-banner { font-family: system-ui, -apple-system, sans-serif; background: #1e40af; color: white; padding: 10px 20px; display: flex; align-items: center; justify-content: space-between; font-size: 13px; box-shadow: 0 -2px 8px rgba(0,0,0,0.2); animation: slideUp 0.3s ease-out; }",
+    ".breach-content { display: flex; align-items: center; gap: 10px; flex: 1; }",
+    ".breach-icon { font-size: 18px; }",
+    ".breach-close { background: rgba(255,255,255,0.2); border: none; color: white; padding: 4px 10px; border-radius: 4px; cursor: pointer; font-size: 12px; font-family: inherit; }",
+    ".breach-close:hover { background: rgba(255,255,255,0.3); }",
+    "@keyframes slideUp { from { transform: translateY(100%); } to { transform: translateY(0); } }",
+  ].join(" ");
+  shadow.appendChild(style);
+
+  const banner = document.createElement("div");
+  banner.className = "breach-banner";
+  banner.setAttribute("role", "status");
+
+  const content = document.createElement("div");
+  content.className = "breach-content";
+
+  const icon = document.createElement("span");
+  icon.className = "breach-icon";
+  icon.textContent = "\uD83D\uDD13";
+  content.appendChild(icon);
+
+  const text = document.createElement("div");
+  text.textContent = reason;
+  content.appendChild(text);
+
+  banner.appendChild(content);
+
+  const closeBtn = document.createElement("button");
+  closeBtn.className = "breach-close";
+  closeBtn.textContent = "Kapat";
+  closeBtn.addEventListener("click", () => host.remove());
+  banner.appendChild(closeBtn);
+
+  shadow.appendChild(banner);
+
+  if (document.body) {
+    document.body.appendChild(host);
+  }
+}
+
 // Run page analysis after DOM is ready
 function runPageAnalysis(): void {
   try {
@@ -99,6 +152,18 @@ function runPageAnalysis(): void {
         ...result,
       }).catch(() => {});
     }
+
+    // Check for breach history
+    chrome.runtime.sendMessage(
+      { type: "CHECK_BREACH", domain },
+      (response: { isBreached: boolean; breaches: { name: string; date: string; dataTypes: string[] }[] } | null) => {
+        if (response?.isBreached && response.breaches.length > 0) {
+          const breach = response.breaches[0];
+          const reason = "Bu site gecmiste veri sizintisina ugramis: " + breach.name + " (" + breach.date + "). Sizabilecek veriler: " + breach.dataTypes.join(", ");
+          createBreachInfoBanner(reason);
+        }
+      },
+    );
   } catch {
     // Silently fail - don't break the page
   }

--- a/src/dashboard/metrics-collector.ts
+++ b/src/dashboard/metrics-collector.ts
@@ -1,0 +1,81 @@
+import { EMPTY_WEEKLY_METRICS, type WeeklyMetrics } from "./types";
+
+export function getWeekStart(timestamp: number): number {
+  const date = new Date(timestamp);
+  const day = date.getUTCDay();
+  const diff = day === 0 ? 6 : day - 1;
+  const monday = new Date(date);
+  monday.setUTCDate(date.getUTCDate() - diff);
+  monday.setUTCHours(0, 0, 0, 0);
+  return monday.getTime();
+}
+
+function getStoredMetrics(): Promise<{ current: WeeklyMetrics; previous: WeeklyMetrics | null }> {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(["weeklyMetrics", "previousWeekMetrics"], (result) => {
+      const currentWeekStart = getWeekStart(Date.now());
+      const stored = result.weeklyMetrics as WeeklyMetrics | undefined;
+      const previous = (result.previousWeekMetrics as WeeklyMetrics) || null;
+
+      if (stored && stored.weekStart === currentWeekStart) {
+        resolve({ current: stored, previous });
+      } else {
+        const newCurrent: WeeklyMetrics = { ...EMPTY_WEEKLY_METRICS, weekStart: currentWeekStart };
+        const newPrevious = stored && stored.weekStart > 0 ? stored : previous;
+        chrome.storage.sync.set({ weeklyMetrics: newCurrent, previousWeekMetrics: newPrevious });
+        resolve({ current: newCurrent, previous: newPrevious });
+      }
+    });
+  });
+}
+
+export async function collectCurrentWeekMetrics(): Promise<WeeklyMetrics> {
+  const { current } = await getStoredMetrics();
+  return current;
+}
+
+export async function collectPreviousWeekMetrics(): Promise<WeeklyMetrics | null> {
+  const { previous } = await getStoredMetrics();
+  return previous;
+}
+
+function updateMetrics(updater: (metrics: WeeklyMetrics) => WeeklyMetrics): Promise<void> {
+  return new Promise((resolve) => {
+    const currentWeekStart = getWeekStart(Date.now());
+    chrome.storage.sync.get(["weeklyMetrics", "previousWeekMetrics"], (result) => {
+      let metrics = result.weeklyMetrics as WeeklyMetrics | undefined;
+
+      if (!metrics || metrics.weekStart !== currentWeekStart) {
+        const newPrevious = metrics && metrics.weekStart > 0 ? metrics : result.previousWeekMetrics;
+        metrics = { ...EMPTY_WEEKLY_METRICS, weekStart: currentWeekStart };
+        const updated = updater(metrics);
+        chrome.storage.sync.set({ weeklyMetrics: updated, previousWeekMetrics: newPrevious }, resolve);
+      } else {
+        const updated = updater(metrics);
+        chrome.storage.sync.set({ weeklyMetrics: updated }, resolve);
+      }
+    });
+  });
+}
+
+export async function recordPageProtocol(url: string): Promise<void> {
+  const isHttps = url.startsWith("https://");
+  const isHttp = url.startsWith("http://");
+  if (!isHttps && !isHttp) return;
+
+  await updateMetrics((m) => ({
+    ...m,
+    httpsCount: m.httpsCount + (isHttps ? 1 : 0),
+    httpCount: m.httpCount + (isHttp ? 1 : 0),
+  }));
+}
+
+export async function recordThreatVisit(level: string): Promise<void> {
+  if (level !== "DANGEROUS" && level !== "SUSPICIOUS") return;
+
+  await updateMetrics((m) => ({
+    ...m,
+    dangerousSitesVisited: m.dangerousSitesVisited + (level === "DANGEROUS" ? 1 : 0),
+    suspiciousSitesVisited: m.suspiciousSitesVisited + (level === "SUSPICIOUS" ? 1 : 0),
+  }));
+}

--- a/src/dashboard/score-calculator.ts
+++ b/src/dashboard/score-calculator.ts
@@ -1,0 +1,86 @@
+import type { WeeklyMetrics, ScoreBreakdown, DashboardData } from "./types";
+
+const ACTIVITY_THRESHOLD = 20;
+
+export function calculateScore(metrics: WeeklyMetrics): DashboardData {
+  const tips: string[] = [];
+  const totalPages = metrics.httpsCount + metrics.httpCount;
+
+  let httpsScore = 0;
+  if (totalPages > 0) {
+    httpsScore = Math.round((metrics.httpsCount / totalPages) * 30);
+  }
+  if (totalPages > 0 && httpsScore < 30) {
+    tips.push(
+      "Guvenli olmayan (HTTP) sitelere dikkat edin. HTTPS olan alternatifleri tercih edin."
+    );
+  }
+
+  let threatAvoidanceScore = 30;
+  if (metrics.urlsChecked > 0) {
+    const dangerousPenalty = metrics.dangerousSitesVisited * 10;
+    const suspiciousPenalty = metrics.suspiciousSitesVisited * 5;
+    threatAvoidanceScore = Math.max(
+      0,
+      30 - dangerousPenalty - suspiciousPenalty
+    );
+  } else {
+    threatAvoidanceScore = 0;
+  }
+  if (metrics.dangerousSitesVisited > 0) {
+    tips.push(
+      `Bu hafta ${metrics.dangerousSitesVisited} tehlikeli siteye girdiniz. Uyarilara dikkat edin.`
+    );
+  }
+  if (
+    metrics.suspiciousSitesVisited > 0 &&
+    metrics.dangerousSitesVisited === 0
+  ) {
+    tips.push(
+      `Bu hafta ${metrics.suspiciousSitesVisited} suppheli site tespit edildi. Dikkatli olun.`
+    );
+  }
+
+  const activityRatio = Math.min(
+    metrics.urlsChecked / ACTIVITY_THRESHOLD,
+    1
+  );
+  const activityScore = Math.round(activityRatio * 20);
+
+  let trackerScore = 0;
+  if (metrics.urlsChecked > 0 && metrics.trackersBlocked > 0) {
+    trackerScore = 20;
+  }
+  if (metrics.urlsChecked > 0 && metrics.trackersBlocked === 0) {
+    tips.push("Tracker engelleyiciyi aktif edin. Gizliliginizi korur.");
+  }
+
+  if (metrics.urlsChecked === 0) {
+    tips.push(
+      "Alparslan aktif degil veya bu hafta hic gezinmediniz. Koruma icin eklentiyi aktif tutun."
+    );
+  }
+
+  const score = Math.min(
+    100,
+    Math.max(
+      0,
+      httpsScore + threatAvoidanceScore + activityScore + trackerScore
+    )
+  );
+
+  const breakdown: ScoreBreakdown = {
+    httpsScore,
+    threatAvoidanceScore,
+    activityScore,
+    trackerScore,
+  };
+
+  return {
+    score,
+    breakdown,
+    currentWeek: metrics,
+    previousWeek: null,
+    tips,
+  };
+}

--- a/src/dashboard/types.ts
+++ b/src/dashboard/types.ts
@@ -1,0 +1,53 @@
+export interface WeeklyMetrics {
+  /** Total URLs checked this week */
+  urlsChecked: number;
+  /** Threats detected and blocked */
+  threatsBlocked: number;
+  /** Trackers blocked */
+  trackersBlocked: number;
+  /** Pages loaded over HTTPS */
+  httpsCount: number;
+  /** Pages loaded over HTTP (insecure) */
+  httpCount: number;
+  /** Number of DANGEROUS-level sites visited */
+  dangerousSitesVisited: number;
+  /** Number of SUSPICIOUS-level sites visited */
+  suspiciousSitesVisited: number;
+  /** Week start timestamp (Monday 00:00) */
+  weekStart: number;
+}
+
+export interface ScoreBreakdown {
+  /** HTTPS usage ratio score (0-30) */
+  httpsScore: number;
+  /** Threat avoidance score (0-30) */
+  threatAvoidanceScore: number;
+  /** Browsing volume score (0-20) -- rewards active protection use */
+  activityScore: number;
+  /** Tracker blocking score (0-20) */
+  trackerScore: number;
+}
+
+export interface DashboardData {
+  /** Overall safety score 0-100 */
+  score: number;
+  /** Score breakdown by category */
+  breakdown: ScoreBreakdown;
+  /** Current week metrics */
+  currentWeek: WeeklyMetrics;
+  /** Previous week metrics (for trend comparison) */
+  previousWeek: WeeklyMetrics | null;
+  /** Human-readable tips based on weakest areas */
+  tips: string[];
+}
+
+export const EMPTY_WEEKLY_METRICS: WeeklyMetrics = {
+  urlsChecked: 0,
+  threatsBlocked: 0,
+  trackersBlocked: 0,
+  httpsCount: 0,
+  httpCount: 0,
+  dangerousSitesVisited: 0,
+  suspiciousSitesVisited: 0,
+  weekStart: 0,
+};

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { DEFAULT_SETTINGS, type ExtensionSettings } from "@/utils/types";
+import type { DashboardData } from "@/dashboard/types";
 
 type ProtectionLevel = ExtensionSettings["protectionLevel"];
 
@@ -14,6 +15,7 @@ export default function Options() {
   const [newDomain, setNewDomain] = useState("");
   const [saved, setSaved] = useState(false);
   const [cleared, setCleared] = useState(false);
+  const [dashboard, setDashboard] = useState<DashboardData | null>(null);
 
   useEffect(() => {
     chrome.storage.sync.get(["settings"], (result) => {
@@ -21,6 +23,14 @@ export default function Options() {
         setSettings({ ...DEFAULT_SETTINGS, ...(result.settings as ExtensionSettings) });
       }
     });
+    chrome.runtime.sendMessage(
+      { type: "GET_DASHBOARD_SCORE" },
+      (response: { dashboard: DashboardData } | null) => {
+        if (response?.dashboard) {
+          setDashboard(response.dashboard);
+        }
+      },
+    );
   }, []);
 
   const saveSettings = useCallback((updated: ExtensionSettings) => {
@@ -71,6 +81,52 @@ export default function Options() {
           </p>
         </div>
       </div>
+
+      {/* Security Score Summary */}
+      {dashboard && (
+        <Section title="Haftalik Guvenlik Ozeti">
+          <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 12 }}>
+            <div
+              style={{
+                width: 64,
+                height: 64,
+                borderRadius: "50%",
+                border: "3px solid " + (dashboard.score >= 80 ? "#16a34a" : dashboard.score >= 50 ? "#d97706" : "#dc2626"),
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 24,
+                fontWeight: 700,
+                color: dashboard.score >= 80 ? "#16a34a" : dashboard.score >= 50 ? "#d97706" : "#dc2626",
+              }}
+            >
+              {dashboard.score}
+            </div>
+            <div>
+              <div style={{ fontSize: 14, fontWeight: 600 }}>
+                {dashboard.score >= 80
+                  ? "Harika! Guvenli geziniyorsunuz."
+                  : dashboard.score >= 50
+                    ? "Iyi, ama iyilestirme alani var."
+                    : "Dikkat! Guvenliginizi artirin."}
+              </div>
+              <div style={{ fontSize: 12, color: "#6b7280", marginTop: 4 }}>
+                Bu hafta {dashboard.currentWeek.urlsChecked} sayfa kontrol edildi
+              </div>
+            </div>
+          </div>
+          {dashboard.tips.length > 0 && (
+            <div style={{ background: "#fffbeb", border: "1px solid #fde68a", borderRadius: 8, padding: "10px 14px" }}>
+              <div style={{ fontSize: 12, fontWeight: 600, color: "#92400e", marginBottom: 6 }}>Oneriler</div>
+              {dashboard.tips.map((tip, i) => (
+                <div key={i} style={{ fontSize: 12, color: "#78350f", padding: "3px 0" }}>
+                  * {tip}
+                </div>
+              ))}
+            </div>
+          )}
+        </Section>
+      )}
 
       {/* Saved notification */}
       {saved && (

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -1,5 +1,8 @@
 import { useState, useEffect } from "react";
 import type { ThreatResult, ExtensionStats, ScanHistoryEntry } from "@/utils/types";
+import TabBar, { type TabId } from "./TabBar";
+import DashboardTab from "./DashboardTab";
+import BreachBadge from "./BreachBadge";
 
 type SecurityStatus = "safe" | "dangerous" | "suspicious" | "unknown" | "loading" | "disabled";
 
@@ -33,6 +36,7 @@ export default function App() {
   const [showHistory, setShowHistory] = useState(false);
   const [history, setHistory] = useState<ScanHistoryEntry[]>([]);
   const [pageReasons, setPageReasons] = useState<string[]>([]);
+  const [activeTab, setActiveTab] = useState<TabId>("status");
 
   useEffect(() => {
     chrome.runtime.sendMessage({ type: "GET_STATS" }, (response: { stats: ExtensionStats } | null) => {
@@ -194,6 +198,12 @@ export default function App() {
         </label>
       </div>
 
+      <TabBar activeTab={activeTab} onTabChange={setActiveTab} />
+
+      {activeTab === "dashboard" ? (
+        <DashboardTab />
+      ) : (
+      <>
       {/* Status */}
       <div
         style={{
@@ -269,6 +279,8 @@ export default function App() {
           </div>
         )}
       </div>
+
+      <BreachBadge domain={displayDomain} />
 
       {/* Stats */}
       <div
@@ -452,6 +464,8 @@ export default function App() {
           </div>
         )}
       </div>
+      </>
+      )}
 
       {/* Footer */}
       <div

--- a/src/popup/BreachBadge.tsx
+++ b/src/popup/BreachBadge.tsx
@@ -1,0 +1,49 @@
+import { useState, useEffect } from "react";
+import type { BreachCheckResult } from "@/breach/types";
+
+interface BreachBadgeProps {
+  domain: string;
+}
+
+export default function BreachBadge({ domain }: BreachBadgeProps) {
+  const [breach, setBreach] = useState<BreachCheckResult | null>(null);
+
+  useEffect(() => {
+    if (!domain) return;
+    chrome.runtime.sendMessage(
+      { type: "CHECK_BREACH", domain },
+      (response: BreachCheckResult | null) => {
+        if (response) setBreach(response);
+      },
+    );
+  }, [domain]);
+
+  if (!domain || !breach?.isBreached || breach.breaches.length === 0) {
+    return null;
+  }
+
+  const latest = breach.breaches[0];
+
+  return (
+    <div
+      style={{
+        margin: "0 16px",
+        padding: "8px 10px",
+        background: "#eff6ff",
+        border: "1px solid #bfdbfe",
+        borderRadius: 6,
+        fontSize: 11,
+        color: "#1e40af",
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+      }}
+    >
+      <span style={{ fontSize: 14 }}>{"\uD83D\uDD13"}</span>
+      <span>
+        Bu sitede veri sizintisi tespit edildi: {latest.name} ({latest.date}).
+        Sizabilecek veriler: {latest.dataTypes.join(", ")}
+      </span>
+    </div>
+  );
+}

--- a/src/popup/DashboardTab.tsx
+++ b/src/popup/DashboardTab.tsx
@@ -1,0 +1,117 @@
+import { useState, useEffect } from "react";
+import type { DashboardData } from "@/dashboard/types";
+
+const BREAKDOWN_LABELS: { key: keyof DashboardData["breakdown"]; label: string; max: number; color: string }[] = [
+  { key: "httpsScore", label: "HTTPS", max: 30, color: "#22c55e" },
+  { key: "threatAvoidanceScore", label: "Tehdit", max: 30, color: "#3b82f6" },
+  { key: "activityScore", label: "Aktivite", max: 20, color: "#8b5cf6" },
+  { key: "trackerScore", label: "Tracker", max: 20, color: "#f59e0b" },
+];
+
+function getScoreColor(score: number): string {
+  if (score >= 80) return "#16a34a";
+  if (score >= 50) return "#d97706";
+  return "#dc2626";
+}
+
+export default function DashboardTab() {
+  const [dashboard, setDashboard] = useState<DashboardData | null>(null);
+
+  useEffect(() => {
+    chrome.runtime.sendMessage(
+      { type: "GET_DASHBOARD_SCORE" },
+      (response: { dashboard: DashboardData } | null) => {
+        if (response?.dashboard) {
+          setDashboard(response.dashboard);
+        }
+      },
+    );
+  }, []);
+
+  if (!dashboard) {
+    return (
+      <div style={{ padding: 24, textAlign: "center", color: "#9ca3af", fontSize: 13 }}>
+        Yukleniyor...
+      </div>
+    );
+  }
+
+  const scoreColor = getScoreColor(dashboard.score);
+
+  return (
+    <div style={{ padding: 16 }}>
+      {/* Score Circle */}
+      <div style={{ textAlign: "center", marginBottom: 16 }}>
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 80,
+            height: 80,
+            borderRadius: "50%",
+            border: "4px solid " + scoreColor,
+          }}
+        >
+          <span style={{ fontSize: 28, fontWeight: 700, color: scoreColor }}>{dashboard.score}</span>
+        </div>
+        <div style={{ fontSize: 12, color: "#6b7280", marginTop: 6 }}>Haftalik Guvenlik Skoru</div>
+      </div>
+
+      {/* Breakdown */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6, marginBottom: 16 }}>
+        {BREAKDOWN_LABELS.map(({ key, label, max, color }) => {
+          const value = dashboard.breakdown[key];
+          const pct = Math.round((value / max) * 100);
+          return (
+            <div key={key}>
+              <div style={{ display: "flex", justifyContent: "space-between", fontSize: 11, color: "#6b7280", marginBottom: 2 }}>
+                <span>{label}</span>
+                <span>{value}/{max}</span>
+              </div>
+              <div style={{ height: 4, borderRadius: 2, background: "#e5e7eb", overflow: "hidden" }}>
+                <div style={{ height: "100%", width: pct + "%", background: color, borderRadius: 2 }} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Weekly Stats */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginBottom: 16 }}>
+        <MiniStat label="Kontrol" value={dashboard.currentWeek.urlsChecked} />
+        <MiniStat
+          label="HTTPS"
+          value={
+            dashboard.currentWeek.httpsCount + dashboard.currentWeek.httpCount > 0
+              ? Math.round((dashboard.currentWeek.httpsCount / (dashboard.currentWeek.httpsCount + dashboard.currentWeek.httpCount)) * 100) + "%"
+              : "0%"
+          }
+        />
+        <MiniStat label="Engellenen Tehdit" value={dashboard.currentWeek.threatsBlocked} />
+        <MiniStat label="Engellenen Tracker" value={dashboard.currentWeek.trackersBlocked} />
+      </div>
+
+      {/* Tips */}
+      {dashboard.tips.length > 0 && (
+        <div style={{ background: "#fffbeb", border: "1px solid #fde68a", borderRadius: 6, padding: "8px 12px" }}>
+          <div style={{ fontSize: 11, fontWeight: 600, color: "#92400e", marginBottom: 4 }}>Oneriler</div>
+          {dashboard.tips.map((tip, i) => (
+            <div key={i} style={{ fontSize: 11, color: "#78350f", padding: "2px 0" }}>
+              * {tip}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MiniStat({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div style={{ background: "#f9fafb", borderRadius: 6, padding: "6px 10px", textAlign: "center" }}>
+      <div style={{ fontSize: 16, fontWeight: 700, color: "#1e293b" }}>{value}</div>
+      <div style={{ fontSize: 10, color: "#9ca3af" }}>{label}</div>
+    </div>
+  );
+}

--- a/src/popup/TabBar.tsx
+++ b/src/popup/TabBar.tsx
@@ -1,0 +1,38 @@
+export type TabId = "status" | "dashboard";
+
+interface TabBarProps {
+  activeTab: TabId;
+  onTabChange: (tab: TabId) => void;
+}
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: "status", label: "Durum" },
+  { id: "dashboard", label: "Skor" },
+];
+
+export default function TabBar({ activeTab, onTabChange }: TabBarProps) {
+  return (
+    <div style={{ display: "flex", borderBottom: "1px solid #e5e7eb", background: "white" }}>
+      {TABS.map((tab) => (
+        <button
+          key={tab.id}
+          onClick={() => onTabChange(tab.id)}
+          style={{
+            flex: 1,
+            padding: "8px 0",
+            background: "transparent",
+            border: "none",
+            borderBottom: activeTab === tab.id ? "2px solid #3b82f6" : "2px solid transparent",
+            color: activeTab === tab.id ? "#3b82f6" : "#6b7280",
+            fontWeight: activeTab === tab.id ? 600 : 400,
+            fontSize: 13,
+            cursor: "pointer",
+            fontFamily: "inherit",
+          }}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/tests/breach/checker.test.ts
+++ b/tests/breach/checker.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach } from "vitest";
+import { checkBreach, loadBreachDatabase, getBreachDatabaseSize } from "@/breach/checker";
+
+const SAMPLE_BREACHES = [
+  { domain: "linkedin.com", name: "LinkedIn 2021", date: "2021-06", accountsAffected: 700000000, dataTypes: ["email", "isim"] },
+  { domain: "yemeksepeti.com", name: "Yemeksepeti 2021", date: "2021-03", accountsAffected: 21000000, dataTypes: ["email", "telefon"] },
+  { domain: "facebook.com", name: "Facebook 2021", date: "2021-04", accountsAffected: 533000000, dataTypes: ["email", "telefon"] },
+];
+
+describe("breach checker", () => {
+  beforeEach(() => {
+    loadBreachDatabase(SAMPLE_BREACHES);
+  });
+
+  it("returns isBreached=true for a known breached domain", () => {
+    const result = checkBreach("linkedin.com");
+    expect(result.isBreached).toBe(true);
+    expect(result.breaches).toHaveLength(1);
+    expect(result.breaches[0].name).toBe("LinkedIn 2021");
+  });
+
+  it("returns isBreached=false for unknown domain", () => {
+    const result = checkBreach("safe-unknown-site.com");
+    expect(result.isBreached).toBe(false);
+    expect(result.breaches).toHaveLength(0);
+  });
+
+  it("matches root domain from full hostname", () => {
+    const result = checkBreach("www.linkedin.com");
+    expect(result.isBreached).toBe(true);
+  });
+
+  it("matches subdomain of breached domain", () => {
+    const result = checkBreach("m.facebook.com");
+    expect(result.isBreached).toBe(true);
+    expect(result.breaches[0].name).toBe("Facebook 2021");
+  });
+
+  it("is case-insensitive", () => {
+    const result = checkBreach("LinkedIn.COM");
+    expect(result.isBreached).toBe(true);
+  });
+
+  it("returns correct database size", () => {
+    expect(getBreachDatabaseSize()).toBe(3);
+  });
+
+  it("handles empty database", () => {
+    loadBreachDatabase([]);
+    const result = checkBreach("linkedin.com");
+    expect(result.isBreached).toBe(false);
+    expect(getBreachDatabaseSize()).toBe(0);
+  });
+
+  it("merges new entries without replacing when replace=false", () => {
+    loadBreachDatabase(
+      [{ domain: "newsite.com", name: "New 2026", date: "2026-01", accountsAffected: 1000, dataTypes: ["email"] }],
+      false,
+    );
+    expect(getBreachDatabaseSize()).toBe(4);
+    expect(checkBreach("linkedin.com").isBreached).toBe(true);
+    expect(checkBreach("newsite.com").isBreached).toBe(true);
+  });
+
+  it("returns multiple breaches for domain with multiple incidents", () => {
+    loadBreachDatabase([
+      ...SAMPLE_BREACHES,
+      { domain: "linkedin.com", name: "LinkedIn 2023", date: "2023-11", accountsAffected: 0, dataTypes: ["email"] },
+    ]);
+    const result = checkBreach("linkedin.com");
+    expect(result.breaches).toHaveLength(2);
+  });
+});

--- a/tests/breach/updater.test.ts
+++ b/tests/breach/updater.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchRemoteBreachDatabase, getBreachApiUrl, setBreachApiUrl } from "@/breach/updater";
+
+vi.mock("@/breach/checker", () => ({
+  loadBreachDatabase: vi.fn(),
+}));
+
+import { loadBreachDatabase } from "@/breach/checker";
+
+describe("breach updater", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+    setBreachApiUrl("https://api.dijitalsavunma.org/v1/breaches");
+  });
+
+  it("fetches and loads breach data on success", async () => {
+    const mockBreaches = [
+      { domain: "test.com", name: "Test Breach", date: "2025-01", accountsAffected: 1000, dataTypes: ["email"] },
+    ];
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ breaches: mockBreaches }),
+    });
+
+    const count = await fetchRemoteBreachDatabase();
+    expect(count).toBe(1);
+    expect(loadBreachDatabase).toHaveBeenCalledWith(mockBreaches, false);
+  });
+
+  it("returns -1 on HTTP error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    const count = await fetchRemoteBreachDatabase();
+    expect(count).toBe(-1);
+    expect(loadBreachDatabase).not.toHaveBeenCalled();
+  });
+
+  it("returns -1 on network error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+
+    const count = await fetchRemoteBreachDatabase();
+    expect(count).toBe(-1);
+  });
+
+  it("returns 0 when response has no breaches array", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: "unexpected" }),
+    });
+
+    const count = await fetchRemoteBreachDatabase();
+    expect(count).toBe(0);
+    expect(loadBreachDatabase).not.toHaveBeenCalled();
+  });
+
+  it("uses configured API URL", async () => {
+    setBreachApiUrl("https://custom.api/breaches");
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ breaches: [] }),
+    });
+
+    await fetchRemoteBreachDatabase();
+    expect(fetch).toHaveBeenCalledWith("https://custom.api/breaches", expect.any(Object));
+  });
+
+  it("getBreachApiUrl returns current URL", () => {
+    setBreachApiUrl("https://example.com/api");
+    expect(getBreachApiUrl()).toBe("https://example.com/api");
+  });
+});

--- a/tests/dashboard/metrics-collector.test.ts
+++ b/tests/dashboard/metrics-collector.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getWeekStart, collectCurrentWeekMetrics, recordPageProtocol, recordThreatVisit } from "@/dashboard/metrics-collector";
+import { EMPTY_WEEKLY_METRICS } from "@/dashboard/types";
+
+describe("getWeekStart", () => {
+  it("returns Monday 00:00:00 for a Wednesday", () => {
+    const wed = new Date("2026-03-25T14:30:00Z").getTime();
+    const weekStart = getWeekStart(wed);
+    const date = new Date(weekStart);
+    expect(date.getUTCDay()).toBe(1);
+    expect(date.getUTCHours()).toBe(0);
+    expect(date.getUTCMinutes()).toBe(0);
+  });
+
+  it("returns same Monday for a Monday input", () => {
+    const mon = new Date("2026-03-23T10:00:00Z").getTime();
+    const weekStart = getWeekStart(mon);
+    const date = new Date(weekStart);
+    expect(date.getUTCDay()).toBe(1);
+    expect(date.toISOString().startsWith("2026-03-23")).toBe(true);
+  });
+
+  it("returns previous Monday for a Sunday", () => {
+    const sun = new Date("2026-03-29T20:00:00Z").getTime();
+    const weekStart = getWeekStart(sun);
+    const date = new Date(weekStart);
+    expect(date.getUTCDay()).toBe(1);
+    expect(date.toISOString().startsWith("2026-03-23")).toBe(true);
+  });
+});
+
+describe("collectCurrentWeekMetrics", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns empty metrics when storage is empty", async () => {
+    vi.spyOn(chrome.storage.sync, "get").mockImplementation(
+      (_keys: unknown, cb: (result: Record<string, unknown>) => void) => cb({})
+    );
+    const result = await collectCurrentWeekMetrics();
+    expect(result).toEqual(expect.objectContaining({
+      urlsChecked: 0,
+      httpsCount: 0,
+      httpCount: 0,
+    }));
+  });
+
+  it("returns stored metrics for current week", async () => {
+    const weekStart = getWeekStart(Date.now());
+    const stored = {
+      weeklyMetrics: { ...EMPTY_WEEKLY_METRICS, urlsChecked: 42, httpsCount: 40, httpCount: 2, weekStart },
+    };
+    vi.spyOn(chrome.storage.sync, "get").mockImplementation(
+      (_keys: unknown, cb: (result: Record<string, unknown>) => void) => cb(stored)
+    );
+    const result = await collectCurrentWeekMetrics();
+    expect(result.urlsChecked).toBe(42);
+    expect(result.httpsCount).toBe(40);
+  });
+
+  it("resets metrics if stored week is old", async () => {
+    const oldWeekStart = getWeekStart(Date.now()) - 7 * 24 * 60 * 60 * 1000;
+    const stored = {
+      weeklyMetrics: { ...EMPTY_WEEKLY_METRICS, urlsChecked: 100, weekStart: oldWeekStart },
+    };
+    vi.spyOn(chrome.storage.sync, "get").mockImplementation(
+      (_keys: unknown, cb: (result: Record<string, unknown>) => void) => cb(stored)
+    );
+    const result = await collectCurrentWeekMetrics();
+    expect(result.urlsChecked).toBe(0);
+  });
+});
+
+describe("recordPageProtocol", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("increments httpsCount for https URL", async () => {
+    const weekStart = getWeekStart(Date.now());
+    const stored = { weeklyMetrics: { ...EMPTY_WEEKLY_METRICS, httpsCount: 5, weekStart } };
+    vi.spyOn(chrome.storage.sync, "get").mockImplementation(
+      (_keys: unknown, cb: (result: Record<string, unknown>) => void) => cb(stored)
+    );
+    const setSpy = vi.spyOn(chrome.storage.sync, "set").mockImplementation(
+      (_items: unknown, cb?: () => void) => cb?.()
+    );
+
+    await recordPageProtocol("https://example.com");
+    expect(setSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ weeklyMetrics: expect.objectContaining({ httpsCount: 6 }) }),
+      expect.any(Function),
+    );
+  });
+
+  it("increments httpCount for http URL", async () => {
+    const weekStart = getWeekStart(Date.now());
+    const stored = { weeklyMetrics: { ...EMPTY_WEEKLY_METRICS, httpCount: 3, weekStart } };
+    vi.spyOn(chrome.storage.sync, "get").mockImplementation(
+      (_keys: unknown, cb: (result: Record<string, unknown>) => void) => cb(stored)
+    );
+    const setSpy = vi.spyOn(chrome.storage.sync, "set").mockImplementation(
+      (_items: unknown, cb?: () => void) => cb?.()
+    );
+
+    await recordPageProtocol("http://example.com");
+    expect(setSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ weeklyMetrics: expect.objectContaining({ httpCount: 4 }) }),
+      expect.any(Function),
+    );
+  });
+});
+
+describe("recordThreatVisit", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("increments dangerousSitesVisited for DANGEROUS level", async () => {
+    const weekStart = getWeekStart(Date.now());
+    const stored = { weeklyMetrics: { ...EMPTY_WEEKLY_METRICS, dangerousSitesVisited: 1, weekStart } };
+    vi.spyOn(chrome.storage.sync, "get").mockImplementation(
+      (_keys: unknown, cb: (result: Record<string, unknown>) => void) => cb(stored)
+    );
+    const setSpy = vi.spyOn(chrome.storage.sync, "set").mockImplementation(
+      (_items: unknown, cb?: () => void) => cb?.()
+    );
+
+    await recordThreatVisit("DANGEROUS");
+    expect(setSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ weeklyMetrics: expect.objectContaining({ dangerousSitesVisited: 2 }) }),
+      expect.any(Function),
+    );
+  });
+
+  it("increments suspiciousSitesVisited for SUSPICIOUS level", async () => {
+    const weekStart = getWeekStart(Date.now());
+    const stored = { weeklyMetrics: { ...EMPTY_WEEKLY_METRICS, suspiciousSitesVisited: 0, weekStart } };
+    vi.spyOn(chrome.storage.sync, "get").mockImplementation(
+      (_keys: unknown, cb: (result: Record<string, unknown>) => void) => cb(stored)
+    );
+    const setSpy = vi.spyOn(chrome.storage.sync, "set").mockImplementation(
+      (_items: unknown, cb?: () => void) => cb?.()
+    );
+
+    await recordThreatVisit("SUSPICIOUS");
+    expect(setSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ weeklyMetrics: expect.objectContaining({ suspiciousSitesVisited: 1 }) }),
+      expect.any(Function),
+    );
+  });
+
+  it("does nothing for SAFE level", async () => {
+    const setSpy = vi.spyOn(chrome.storage.sync, "set");
+
+    await recordThreatVisit("SAFE");
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/dashboard/score-calculator.test.ts
+++ b/tests/dashboard/score-calculator.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { calculateScore } from "@/dashboard/score-calculator";
+import { EMPTY_WEEKLY_METRICS, type WeeklyMetrics } from "@/dashboard/types";
+
+describe("calculateScore", () => {
+  it("returns 0 score with empty metrics", () => {
+    const result = calculateScore(EMPTY_WEEKLY_METRICS);
+    expect(result.score).toBe(0);
+    expect(result.breakdown.httpsScore).toBe(0);
+    expect(result.breakdown.threatAvoidanceScore).toBe(0);
+    expect(result.breakdown.activityScore).toBe(0);
+    expect(result.breakdown.trackerScore).toBe(0);
+    expect(result.tips.length).toBeGreaterThan(0);
+  });
+
+  it("returns perfect score for ideal browsing", () => {
+    const metrics: WeeklyMetrics = {
+      urlsChecked: 100,
+      threatsBlocked: 5,
+      trackersBlocked: 50,
+      httpsCount: 100,
+      httpCount: 0,
+      dangerousSitesVisited: 0,
+      suspiciousSitesVisited: 0,
+      weekStart: Date.now(),
+    };
+    const result = calculateScore(metrics);
+    expect(result.score).toBe(100);
+    expect(result.breakdown.httpsScore).toBe(30);
+    expect(result.breakdown.threatAvoidanceScore).toBe(30);
+    expect(result.breakdown.activityScore).toBe(20);
+    expect(result.breakdown.trackerScore).toBe(20);
+    expect(result.tips).toEqual([]);
+  });
+
+  it("penalizes HTTP usage", () => {
+    const metrics: WeeklyMetrics = {
+      ...EMPTY_WEEKLY_METRICS,
+      urlsChecked: 100,
+      httpsCount: 50,
+      httpCount: 50,
+      weekStart: Date.now(),
+    };
+    const result = calculateScore(metrics);
+    expect(result.breakdown.httpsScore).toBe(15);
+    expect(result.tips).toContain(
+      "Guvenli olmayan (HTTP) sitelere dikkat edin. HTTPS olan alternatifleri tercih edin."
+    );
+  });
+
+  it("penalizes visiting dangerous sites", () => {
+    const metrics: WeeklyMetrics = {
+      ...EMPTY_WEEKLY_METRICS,
+      urlsChecked: 50,
+      httpsCount: 50,
+      httpCount: 0,
+      dangerousSitesVisited: 3,
+      suspiciousSitesVisited: 2,
+      weekStart: Date.now(),
+    };
+    const result = calculateScore(metrics);
+    expect(result.breakdown.threatAvoidanceScore).toBeLessThan(30);
+    expect(result.tips.some((t) => t.includes("tehlikeli"))).toBe(true);
+  });
+
+  it("gives partial activity score for low browsing volume", () => {
+    const metrics: WeeklyMetrics = {
+      ...EMPTY_WEEKLY_METRICS,
+      urlsChecked: 5,
+      httpsCount: 5,
+      weekStart: Date.now(),
+    };
+    const result = calculateScore(metrics);
+    expect(result.breakdown.activityScore).toBe(5);
+  });
+
+  it("caps activity score at 20", () => {
+    const metrics: WeeklyMetrics = {
+      ...EMPTY_WEEKLY_METRICS,
+      urlsChecked: 500,
+      httpsCount: 500,
+      weekStart: Date.now(),
+    };
+    const result = calculateScore(metrics);
+    expect(result.breakdown.activityScore).toBe(20);
+  });
+
+  it("gives tracker score based on blocking ratio", () => {
+    const metrics: WeeklyMetrics = {
+      ...EMPTY_WEEKLY_METRICS,
+      urlsChecked: 100,
+      httpsCount: 100,
+      trackersBlocked: 10,
+      weekStart: Date.now(),
+    };
+    const result = calculateScore(metrics);
+    expect(result.breakdown.trackerScore).toBe(20);
+  });
+
+  it("gives 0 tracker score when no trackers blocked despite activity", () => {
+    const metrics: WeeklyMetrics = {
+      ...EMPTY_WEEKLY_METRICS,
+      urlsChecked: 100,
+      httpsCount: 100,
+      trackersBlocked: 0,
+      weekStart: Date.now(),
+    };
+    const result = calculateScore(metrics);
+    expect(result.breakdown.trackerScore).toBe(0);
+    expect(result.tips).toContain(
+      "Tracker engelleyiciyi aktif edin. Gizliliginizi korur."
+    );
+  });
+
+  it("clamps total score between 0 and 100", () => {
+    const metrics: WeeklyMetrics = {
+      urlsChecked: 1000,
+      threatsBlocked: 500,
+      trackersBlocked: 1000,
+      httpsCount: 1000,
+      httpCount: 0,
+      dangerousSitesVisited: 0,
+      suspiciousSitesVisited: 0,
+      weekStart: Date.now(),
+    };
+    const result = calculateScore(metrics);
+    expect(result.score).toBeLessThanOrEqual(100);
+    expect(result.score).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/tests/popup/BreachBadge.test.tsx
+++ b/tests/popup/BreachBadge.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import BreachBadge from "@/popup/BreachBadge";
+
+describe("BreachBadge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders breach warning when domain is breached", async () => {
+    chrome.runtime.sendMessage = vi.fn((msg: unknown, cb?: unknown) => {
+      const message = msg as { type: string };
+      const callback = cb as ((response: unknown) => void) | undefined;
+      if (message.type === "CHECK_BREACH" && callback) {
+        callback({
+          isBreached: true,
+          breaches: [{ name: "Test 2021", date: "2021-06", dataTypes: ["email", "sifre"] }],
+        });
+      }
+    }) as unknown as typeof chrome.runtime.sendMessage;
+    render(<BreachBadge domain="example.com" />);
+    await waitFor(() => {
+      expect(screen.getByText(/veri sizintisi/)).toBeDefined();
+    });
+  });
+
+  it("renders nothing when domain is not breached", async () => {
+    chrome.runtime.sendMessage = vi.fn((msg: unknown, cb?: unknown) => {
+      const message = msg as { type: string };
+      const callback = cb as ((response: unknown) => void) | undefined;
+      if (message.type === "CHECK_BREACH" && callback) {
+        callback({ isBreached: false, breaches: [] });
+      }
+    }) as unknown as typeof chrome.runtime.sendMessage;
+    const { container } = render(<BreachBadge domain="safe-site.com" />);
+    await waitFor(() => {
+      expect(container.textContent).toBe("");
+    });
+  });
+
+  it("renders nothing for empty domain", () => {
+    const { container } = render(<BreachBadge domain="" />);
+    expect(container.textContent).toBe("");
+  });
+});

--- a/tests/popup/DashboardTab.test.tsx
+++ b/tests/popup/DashboardTab.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import DashboardTab from "@/popup/DashboardTab";
+
+describe("DashboardTab", () => {
+  const mockDashboard = {
+    score: 72,
+    breakdown: { httpsScore: 25, threatAvoidanceScore: 27, activityScore: 10, trackerScore: 10 },
+    currentWeek: { urlsChecked: 50, httpsCount: 45, httpCount: 5, threatsBlocked: 2, trackersBlocked: 30, dangerousSitesVisited: 0, suspiciousSitesVisited: 1, weekStart: Date.now() },
+    previousWeek: null,
+    tips: ["Guvenli olmayan (HTTP) sitelere dikkat edin. HTTPS olan alternatifleri tercih edin."],
+  };
+
+  beforeEach(() => {
+    chrome.runtime.sendMessage = vi.fn((msg: unknown, cb?: unknown) => {
+      const message = msg as { type: string };
+      const callback = cb as ((response: unknown) => void) | undefined;
+      if (message.type === "GET_DASHBOARD_SCORE" && callback) {
+        callback({ dashboard: mockDashboard });
+      }
+    }) as unknown as typeof chrome.runtime.sendMessage;
+  });
+
+  it("renders score value", async () => {
+    render(<DashboardTab />);
+    await waitFor(() => {
+      expect(screen.getByText("72")).toBeDefined();
+    });
+  });
+
+  it("renders score breakdown categories", async () => {
+    render(<DashboardTab />);
+    await waitFor(() => {
+      expect(screen.getAllByText("HTTPS").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Tehdit")).toBeDefined();
+      expect(screen.getByText("Aktivite")).toBeDefined();
+      expect(screen.getAllByText("Tracker").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("renders tips when present", async () => {
+    render(<DashboardTab />);
+    await waitFor(() => {
+      expect(screen.getByText(/HTTPS olan alternatifleri/)).toBeDefined();
+    });
+  });
+
+  it("shows loading state initially", () => {
+    chrome.runtime.sendMessage = vi.fn() as unknown as typeof chrome.runtime.sendMessage;
+    render(<DashboardTab />);
+    expect(screen.getByText("Yukleniyor...")).toBeDefined();
+  });
+});

--- a/tests/popup/TabBar.test.tsx
+++ b/tests/popup/TabBar.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import TabBar from "@/popup/TabBar";
+
+describe("TabBar", () => {
+  it("renders two tabs", () => {
+    render(<TabBar activeTab="status" onTabChange={() => {}} />);
+    expect(screen.getByText("Durum")).toBeDefined();
+    expect(screen.getByText("Skor")).toBeDefined();
+  });
+
+  it("highlights active tab", () => {
+    render(<TabBar activeTab="dashboard" onTabChange={() => {}} />);
+    const dashboardTab = screen.getByText("Skor");
+    expect(dashboardTab.closest("button")?.style.borderBottom).toContain("solid");
+  });
+
+  it("calls onTabChange when clicked", () => {
+    const handler = vi.fn();
+    render(<TabBar activeTab="status" onTabChange={handler} />);
+    fireEvent.click(screen.getByText("Skor"));
+    expect(handler).toHaveBeenCalledWith("dashboard");
+  });
+});


### PR DESCRIPTION
- **Security Score Dashboard**: Weekly personal safety score (0-100) based on HTTPS usage (0-30), threat avoidance (0-30), browsing activity (0-20), and tracker blocking (0-20). Displayed as a new "Skor" tab in the popup and a summary section in the options page. Provides actionable Turkish-language tips based on weakest areas.
- **Site Breach Check**: Warns users when they visit a site with known data breaches. Ships with a built-in database of 20 major breaches (LinkedIn, Facebook, Yahoo, Yemeksepeti, etc.) and supports remote updates via `api.dijitalsavunma.org`. Shows a blue info banner on breached
  pages and a badge in the popup.
- **E2E Test Infrastructure**: Full Playwright setup with extension loading fixture for Chromium. 28 E2E tests covering popup navigation,
  dashboard score display, breach detection, and options page (happy + negative scenarios).

  ## New Modules

  | Module | Files | Purpose |
  |--------|-------|---------|
  | `src/dashboard/` | `types.ts`, `score-calculator.ts`, `metrics-collector.ts` | Weekly metrics collection & score calculation |
  | `src/breach/` | `types.ts`, `checker.ts`, `updater.ts` | Breach database, domain checker, remote updater |
  | `src/popup/` | `TabBar.tsx`, `DashboardTab.tsx`, `BreachBadge.tsx` | New popup UI components |
  | `e2e/` | `fixtures/`, `helpers/`, `specs/` | Playwright E2E test infrastructure |
  | `lists/` | `breached-sites.json` | Built-in breach database (20 entries) |

  ## Test Coverage

  - **45 unit tests** (Vitest) — score calculator, metrics collector, breach checker, breach updater, TabBar, DashboardTab, BreachBadge
  - **26 E2E tests** (Playwright) — popup navigation, dashboard, breach check, options page
  - **2 E2E tests skipped** — breach badge popup tests due to Playwright extension active-tab limitation

  ## How to Test

  ```bash
  # Unit tests
  npm test

  # Build extension
  npm run build

  # E2E tests (requires headed Chromium)
  npm run test:e2e

  Screenshots

  Load the extension from dist/ in Chrome developer mode to see:
  - Popup > Skor tab: Weekly score circle, breakdown bars, stats grid, tips
  - Popup > Durum tab: Breach badge (visit linkedin.com to trigger)
  - Breached site page: Blue info banner at bottom
  - Options page: "Haftalik Guvenlik Ozeti" section