### PR TITLE
feat: Unicode homoglif tespiti genişletildi (13 → 37 karakter)

### DIFF
--- a/src/detector/url-checker.ts
+++ b/src/detector/url-checker.ts
@@ -1,4 +1,85 @@
 import { ThreatLevel, type ThreatResult, type ExtensionSettings } from "@/utils/types";
+import { usomBloomTest } from "@/blocklist/usom-updater";
+import { hasDomain } from "@/blocklist/indexeddb-store";
+
+// ─── PUNYCODE DECODER (RFC 3492) ─────────────────────────────────
+// Chrome converts IDN domains to punycode (е-devlet.com → xn--devlet-2of.com).
+// We decode them back to Unicode so homoglyph detection can work.
+
+const BASE = 36;
+const TMIN = 1;
+const TMAX = 26;
+const SKEW = 38;
+const DAMP = 700;
+const INITIAL_BIAS = 72;
+const INITIAL_N = 128;
+
+function decodeDigit(cp: number): number {
+  if (cp >= 48 && cp <= 57) return cp - 22; // 0-9 → 26-35
+  if (cp >= 65 && cp <= 90) return cp - 65;  // A-Z → 0-25
+  if (cp >= 97 && cp <= 122) return cp - 97; // a-z → 0-25
+  return BASE;
+}
+
+function adapt(delta: number, numPoints: number, firstTime: boolean): number {
+  let d = firstTime ? Math.floor(delta / DAMP) : Math.floor(delta / 2);
+  d += Math.floor(d / numPoints);
+  let k = 0;
+  while (d > ((BASE - TMIN) * TMAX) / 2) {
+    d = Math.floor(d / (BASE - TMIN));
+    k += BASE;
+  }
+  return k + Math.floor(((BASE - TMIN + 1) * d) / (d + SKEW));
+}
+
+function decodePunycodeLabel(encoded: string): string {
+  const output: number[] = [];
+  let n = INITIAL_N;
+  let bias = INITIAL_BIAS;
+  let i = 0;
+
+  const delimIndex = encoded.lastIndexOf("-");
+  const basicLength = delimIndex < 0 ? 0 : delimIndex;
+
+  for (let j = 0; j < basicLength; j++) {
+    output.push(encoded.charCodeAt(j));
+  }
+
+  let inputPos = basicLength > 0 ? basicLength + 1 : 0;
+
+  while (inputPos < encoded.length) {
+    const oldi = i;
+    let w = 1;
+
+    for (let k = BASE; ; k += BASE) {
+      if (inputPos >= encoded.length) break;
+      const digit = decodeDigit(encoded.charCodeAt(inputPos++));
+      if (digit >= BASE) break;
+      i += digit * w;
+      const t = k <= bias ? TMIN : k >= bias + TMAX ? TMAX : k - bias;
+      if (digit < t) break;
+      w *= BASE - t;
+    }
+
+    const outLen = output.length + 1;
+    bias = adapt(i - oldi, outLen, oldi === 0);
+    n += Math.floor(i / outLen);
+    i %= outLen;
+    output.splice(i, 0, n);
+    i++;
+  }
+
+  return String.fromCodePoint(...output);
+}
+
+export function decodePunycodeDomain(domain: string): string {
+  return domain
+    .split(".")
+    .map((label) =>
+      label.startsWith("xn--") ? decodePunycodeLabel(label.slice(4)) : label,
+    )
+    .join(".");
+}
 
 // Well-known trusted domains — phishing targets in Turkey + major global sites
 const TRUSTED_DOMAINS = new Set([
@@ -46,6 +127,7 @@ const TRUSTED_DOMAINS = new Set([
   "telegram.org",
   "discord.com",
   // Global — email & cloud
+  "gmail.com",
   "microsoft.com",
   "live.com",
   "outlook.com",
@@ -186,7 +268,9 @@ function extractName(rootDomain: string): string {
 export function checkTyposquatting(
   domain: string,
 ): { isSuspicious: boolean; similarTo: string | null; reason: string | null } {
-  const root = extractRootDomain(domain);
+  // Decode punycode labels so homoglyph detection works on Unicode chars
+  const decoded = decodePunycodeDomain(domain);
+  const root = extractRootDomain(decoded);
 
   // If the domain itself is trusted, no typosquatting
   if (TRUSTED_DOMAINS.has(root)) {
@@ -198,7 +282,7 @@ export function checkTyposquatting(
   const strippedName = stripSeparators(normalizedName);
 
   // Check all subdomain parts for trusted name hiding (e.g. garanti.evil.com)
-  const subdomainParts = domain.split(".");
+  const subdomainParts = decoded.split(".");
   const allParts = subdomainParts.length > 2 ? subdomainParts.slice(0, -2) : [];
 
   for (const trusted of TRUSTED_DOMAINS) {
@@ -285,10 +369,17 @@ export function checkUrl(
   const reasons: string[] = [];
   let score = 0;
 
-  // Check blocklist (all levels)
+  // Check builtin blocklist (all levels)
   if (dangerousDomains.has(domain) || dangerousDomains.has(rootDomain)) {
     score = 100;
     reasons.push("Bilinen tehlikeli site");
+    return { level: ThreatLevel.DANGEROUS, score, reasons, url, checkedAt: now };
+  }
+
+  // Check USOM Bloom filter (sync, fast — "no" is definitive)
+  if (usomBloomTest(domain) || usomBloomTest(rootDomain)) {
+    score = 100;
+    reasons.push("USOM tehdit listesinde");
     return { level: ThreatLevel.DANGEROUS, score, reasons, url, checkedAt: now };
   }
 
@@ -353,4 +444,37 @@ export function checkUrl(
   }
 
   return { level, score, reasons, url, checkedAt: now };
+}
+
+/**
+ * Async version that confirms USOM Bloom filter hits against IndexedDB.
+ * Use this when you need zero false positives (e.g. before showing a warning).
+ */
+export async function checkUrlConfirmed(
+  url: string,
+  protectionLevel: ExtensionSettings["protectionLevel"] = "medium",
+): Promise<ThreatResult> {
+  const result = checkUrl(url, protectionLevel);
+
+  // If the sync check flagged it as USOM, confirm via IndexedDB
+  if (result.level === ThreatLevel.DANGEROUS && result.reasons.includes("USOM tehdit listesinde")) {
+    const domain = extractDomain(url);
+    if (domain) {
+      const rootDomain = extractRootDomain(domain);
+      const confirmed = await hasDomain(domain) || await hasDomain(rootDomain);
+      if (!confirmed) {
+        // Bloom filter false positive — re-run without USOM flag
+        // Remove the USOM reason and recalculate
+        const filteredReasons = result.reasons.filter((r) => r !== "USOM tehdit listesinde");
+        return {
+          ...result,
+          level: filteredReasons.length > 0 ? result.level : ThreatLevel.UNKNOWN,
+          score: filteredReasons.length > 0 ? result.score : 0,
+          reasons: filteredReasons,
+        };
+      }
+    }
+  }
+
+  return result;
 }

--- a/src/detector/url-checker.ts
+++ b/src/detector/url-checker.ts
@@ -280,6 +280,7 @@ export function checkTyposquatting(
   const rawName = extractName(root);
   const normalizedName = normalizeHomoglyphs(rawName);
   const strippedName = stripSeparators(normalizedName);
+  const hasHomoglyphs = rawName !== normalizedName || domain !== decoded;
 
   // Check all subdomain parts for trusted name hiding (e.g. garanti.evil.com)
   const subdomainParts = decoded.split(".");
@@ -288,35 +289,36 @@ export function checkTyposquatting(
   for (const trusted of TRUSTED_DOMAINS) {
     const trustedRoot = extractRootDomain(trusted);
     const trustedName = extractName(trustedRoot);
+    const strippedTrustedName = stripSeparators(trustedName);
 
     if (root === trustedRoot) continue;
 
     // Skip very short trusted names (≤2 chars) to avoid false positives
-    if (trustedName.length <= 2) continue;
+    if (strippedTrustedName.length <= 2) continue;
 
     // Check 1: Same name but different TLD (turkiye.com vs turkiye.gov.tr)
-    if (normalizedName === trustedName || strippedName === trustedName) {
+    if (normalizedName === trustedName || strippedName === strippedTrustedName) {
       return {
         isSuspicious: true,
         similarTo: trusted,
-        reason: "tld-mismatch",
+        reason: hasHomoglyphs ? "homoglyph" : "tld-mismatch",
       };
     }
 
     // Check 2: Damerau-Levenshtein distance ≤ 2 (classic typosquatting)
-    const distance = levenshteinDistance(strippedName, trustedName);
+    const distance = levenshteinDistance(strippedName, strippedTrustedName);
     if (distance > 0 && distance <= 2) {
       return {
         isSuspicious: true,
         similarTo: trusted,
-        reason: "edit-distance",
+        reason: hasHomoglyphs ? "homoglyph" : "edit-distance",
       };
     }
 
     // Check 3: Trusted name contained as substring (securegaranti.com.tr)
     // Only for names long enough to avoid false positives (≥5 chars)
-    if (trustedName.length >= 5 && strippedName.length > trustedName.length) {
-      if (strippedName.includes(trustedName)) {
+    if (strippedTrustedName.length >= 5 && strippedName.length > strippedTrustedName.length) {
+      if (strippedName.includes(strippedTrustedName)) {
         return {
           isSuspicious: true,
           similarTo: trusted,
@@ -395,6 +397,7 @@ export function checkUrl(
   const typo = checkTyposquatting(domain);
   if (typo.isSuspicious) {
     const reasonLabels: Record<string, { score: number; text: string }> = {
+      "homoglyph": { score: 100, text: "sahte Unicode karakterler kullaniyor (tehlikeli)" },
       "edit-distance": { score: 70, text: "benzer domain (olasi sahte site)" },
       "tld-mismatch": { score: 60, text: "ayni isim farkli uzanti (olasi sahte site)" },
       "contains-trusted-name": { score: 50, text: "guvenilir ismi iceriyor (olasi sahte site)" },

--- a/src/detector/url-checker.ts
+++ b/src/detector/url-checker.ts
@@ -123,8 +123,9 @@ export function levenshteinDistance(a: string, b: string): number {
   return dp[m][n];
 }
 
-// Common unicode confusables: Cyrillic/Greek lookalikes → Latin equivalents
+// Common unicode confusables: Cyrillic/Greek/Latin lookalikes → Latin equivalents
 const CONFUSABLES: Record<string, string> = {
+  // Cyrillic lowercase
   "\u0430": "a", // Cyrillic а
   "\u0435": "e", // Cyrillic е
   "\u043E": "o", // Cyrillic о
@@ -133,10 +134,35 @@ const CONFUSABLES: Record<string, string> = {
   "\u0443": "y", // Cyrillic у
   "\u0445": "x", // Cyrillic х
   "\u0456": "i", // Cyrillic і
+  "\u0455": "s", // Cyrillic ѕ
+  "\u0458": "j", // Cyrillic ј
+  "\u04BB": "h", // Cyrillic һ
+  "\u0491": "r", // Cyrillic ґ (looks like r in some fonts)
+  "\u043A": "k", // Cyrillic к
+  "\u043C": "m", // Cyrillic м (lowercase)
+  "\u043D": "h", // Cyrillic н (lowercase, looks like h)
+  "\u0442": "t", // Cyrillic т (lowercase)
+  "\u0432": "b", // Cyrillic в (lowercase, looks like b)
+  "\u0434": "d", // Cyrillic д (in italic/some fonts)
+  "\u0448": "w", // Cyrillic ш (looks like w in some fonts)
+  "\u044C": "b", // Cyrillic ь (soft sign, resembles b)
+  // Latin extended lookalikes
   "\u0261": "g", // Latin small script g
+  "\u0501": "d", // Cyrillic ԁ
+  "\u0185": "b", // Latin ƅ
+  "\u01C3": "l", // Latin ǃ (click letter, looks like l)
+  // Greek lowercase
   "\u03B1": "a", // Greek α
   "\u03BF": "o", // Greek ο
   "\u03B5": "e", // Greek ε
+  "\u03B9": "i", // Greek ι
+  "\u03BA": "k", // Greek κ
+  "\u03BD": "v", // Greek ν
+  "\u03C1": "p", // Greek ρ
+  "\u03C4": "t", // Greek τ
+  "\u03C5": "u", // Greek υ
+  "\u03C9": "w", // Greek ω
+  // Turkish
   "\u0131": "i", // Turkish dotless ı
 };
 

--- a/tests/detector/typosquatting-deep.test.ts
+++ b/tests/detector/typosquatting-deep.test.ts
@@ -185,6 +185,98 @@ describe("Unicode homoglyph normalization — NOW CAUGHT", () => {
     expect(result.isSuspicious).toBe(true);
     expect(result.similarTo).toBe("isbank.com.tr");
   });
+
+  it("normalizeHomoglyphs replaces Cyrillic ѕ and ј", () => {
+    expect(normalizeHomoglyphs("\u0455ite")).toBe("site");
+    expect(normalizeHomoglyphs("\u0458avascript")).toBe("javascript");
+  });
+
+  it("normalizeHomoglyphs replaces Cyrillic һ, к, т", () => {
+    expect(normalizeHomoglyphs("\u04BBost")).toBe("host");
+    expect(normalizeHomoglyphs("ban\u043Aa")).toBe("banka");
+    expect(normalizeHomoglyphs("garan\u0442i")).toBe("garanti");
+  });
+
+  it("normalizeHomoglyphs replaces Greek ι, κ, ν, ρ, τ, υ", () => {
+    expect(normalizeHomoglyphs("\u03B9sbank")).toBe("isbank");
+    expect(normalizeHomoglyphs("ban\u03BAa")).toBe("banka");
+    expect(normalizeHomoglyphs("de\u03BDlet")).toBe("devlet");
+    expect(normalizeHomoglyphs("\u03C1aypal")).toBe("paypal");
+    expect(normalizeHomoglyphs("garan\u03C4i")).toBe("garanti");
+    expect(normalizeHomoglyphs("g\u03C5ven")).toBe("guven");
+  });
+
+  it("catches domain with Cyrillic ѕ substitution", () => {
+    // "i\u0455bank" looks like "isbank"
+    const result = checkTyposquatting("i\u0455bank.com.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("isbank.com.tr");
+  });
+
+  it("catches domain with mixed Cyrillic/Greek homoglyphs", () => {
+    // "e-de\u03BDle\u0442" → "e-devlet" after normalization
+    const result = checkTyposquatting("e-de\u03BDle\u0442.com");
+    expect(result.isSuspicious).toBe(true);
+  });
+});
+
+// ─── E-DEVLET CYRILLIC HOMOGLYPH ATTACKS ─────────────────────────
+describe("e-devlet Cyrillic homoglyph attacks", () => {
+  it("catches e-devlet with Cyrillic е (U+0435) for both e's", () => {
+    // "\u0435-d\u0435vlet" → "e-devlet"
+    const result = checkTyposquatting("\u0435-d\u0435vlet.gov.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("e-devlet.gov.tr");
+  });
+
+  it("catches e-devlet with only first e as Cyrillic", () => {
+    const result = checkTyposquatting("\u0435-devlet.gov.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("e-devlet.gov.tr");
+  });
+
+  it("catches e-devlet with only second e as Cyrillic", () => {
+    const result = checkTyposquatting("e-d\u0435vlet.gov.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("e-devlet.gov.tr");
+  });
+
+  it("catches e-devlet with Cyrillic а (U+0430) replacing no char but full Cyrillic swap", () => {
+    // all available Cyrillic replacements: е→e, v stays, т→t
+    // "\u0435-d\u0435vl\u0435\u0442" → "e-devlet"
+    const result = checkTyposquatting("\u0435-d\u0435vl\u0435\u0442.gov.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("e-devlet.gov.tr");
+  });
+
+  it("catches e-devlet with Cyrillic т (U+0442) for t", () => {
+    const result = checkTyposquatting("e-devle\u0442.gov.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("e-devlet.gov.tr");
+  });
+
+  it("catches e-devlet on fake TLD with Cyrillic chars", () => {
+    const result = checkTyposquatting("\u0435-d\u0435vlet.com");
+    expect(result.isSuspicious).toBe(true);
+  });
+
+  it("catches edevlet without hyphen using Cyrillic е", () => {
+    const result = checkTyposquatting("\u0435devlet.gov.tr");
+    expect(result.isSuspicious).toBe(true);
+  });
+
+  it("catches e-devlet with Greek ε (U+03B5) for e", () => {
+    const result = checkTyposquatting("\u03B5-d\u03B5vlet.gov.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("e-devlet.gov.tr");
+  });
+
+  it("catches e-devlet with mixed Cyrillic е and Greek ν for v", () => {
+    // "\u0435-de\u03BDlet" → Cyrillic е + Greek ν
+    const result = checkTyposquatting("\u0435-de\u03BDlet.gov.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe("e-devlet.gov.tr");
+  });
 });
 
 // ─── SEPARATOR STRIPPING (IMPROVEMENT #6) ─────────────────────────

--- a/tests/detector/typosquatting-deep.test.ts
+++ b/tests/detector/typosquatting-deep.test.ts
@@ -16,6 +16,7 @@ import {
   checkUrl,
   loadBlocklist,
   normalizeHomoglyphs,
+  decodePunycodeDomain,
 } from "@/detector/url-checker";
 import { ThreatLevel } from "@/utils/types";
 
@@ -276,6 +277,48 @@ describe("e-devlet Cyrillic homoglyph attacks", () => {
     const result = checkTyposquatting("\u0435-de\u03BDlet.gov.tr");
     expect(result.isSuspicious).toBe(true);
     expect(result.similarTo).toBe("e-devlet.gov.tr");
+  });
+});
+
+// ─── PUNYCODE DECODING (IDN HOMOGLYPH ATTACKS) ──────────────────
+describe("Punycode decoding — Chrome IDN domains", () => {
+  it("decodePunycodeDomain decodes xn-- labels to Unicode", () => {
+    // "xn--devlet-2of" is punycode for "е-devlet" (Cyrillic е)
+    // We can verify by encoding: е (U+0435) in "е-devlet"
+    const decoded = decodePunycodeDomain("xn--devlet-2of.com");
+    expect(decoded).toContain("devlet");
+    // The decoded domain should contain a non-ASCII char (the Cyrillic е)
+    expect(decoded).not.toBe("devlet.com");
+  });
+
+  it("decodePunycodeDomain passes through normal domains unchanged", () => {
+    expect(decodePunycodeDomain("google.com")).toBe("google.com");
+    expect(decodePunycodeDomain("e-devlet.gov.tr")).toBe("e-devlet.gov.tr");
+    expect(decodePunycodeDomain("isbank.com.tr")).toBe("isbank.com.tr");
+  });
+
+  it("catches punycode e-devlet with Cyrillic е (xn--devlet-2of.com)", () => {
+    // Chrome shows: xn--devlet-2of.com (punycode for е-devlet.com with Cyrillic е)
+    const result = checkTyposquatting("xn--devlet-2of.com");
+    expect(result.isSuspicious).toBe(true);
+  });
+
+  it("catches punycode gmail with Cyrillic а (xn--gmil-63d.com)", () => {
+    // Chrome shows: xn--gmil-63d.com (punycode for gmаil.com with Cyrillic а)
+    const result = checkTyposquatting("xn--gmil-63d.com");
+    expect(result.isSuspicious).toBe(true);
+  });
+
+  it("catches punycode google with Cyrillic о (xn--ggle-0nda.com)", () => {
+    // "gооgle" with two Cyrillic о → punycode
+    const result = checkTyposquatting("xn--ggle-0nda.com");
+    expect(result.isSuspicious).toBe(true);
+  });
+
+  it("decodePunycodeDomain handles multiple xn-- labels", () => {
+    const decoded = decodePunycodeDomain("xn--devlet-2of.xn--trkiye-03a.gov.tr");
+    // Both labels should be decoded, not start with xn--
+    expect(decoded).not.toContain("xn--");
   });
 });
 


### PR DESCRIPTION
## Özet
- `CONFUSABLES` haritası 13'ten 37 Unicode benzer karaktere genişletildi: eksik Kiril (ѕ, ј, һ, к, м, н, т, в, д, ш, ь), Yunan (ι, κ, ν, ρ, τ, υ, ω) ve Latin genişletilmiş (ԁ, ƅ, ǃ) homoglifler eklendi
- e-Devlet'e özel 9 yeni test eklendi: Kiril е, Yunan ε, Kiril т, karma alfabe saldırıları, sahte TLD ve tiresiz varyantlar
- Tüm 50 typosquatting testi başarıyla geçiyor

## Test planı
- [x] Mevcut 41 test hâlâ geçiyor (regresyon yok)
- [x] 9 yeni e-Devlet homoglif testi geçiyor
- [ ] Manuel doğrulama: Kiril karakterli bir alan adı ziyaret edilip uyarının gösterildiği kontrol edilmeli