### PR TITLE
ci: add PR gates for unit tests and Playwright e2e

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,64 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: e2e-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Playwright e2e (Chromium + extension)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers + OS deps
+        run: npx playwright install --with-deps chromium
+
+      - name: Build extension
+        run: npm run build
+
+      # The extension fixture launches Chromium with `headless: false`
+      # (required for MV3 extension loading). xvfb-run provides a
+      # virtual X display so the browser can start without a physical
+      # screen on GitHub-hosted runners.
+      - name: Run Playwright tests
+        run: xvfb-run --auto-servernum -- npx playwright test --config e2e/playwright.config.ts
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload test results (traces + screenshots)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Manual trigger from the Actions tab with a branch picker.
+  workflow_dispatch:
 
 concurrency:
   group: e2e-tests-${{ github.ref }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,39 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Type check, build, unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check + build (Chrome)
+        run: npm run build
+
+      - name: Unit tests
+        run: npm test

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Manual trigger from the Actions tab with a branch picker.
+  workflow_dispatch:
 
 concurrency:
   group: unit-tests-${{ github.ref }}


### PR DESCRIPTION
## Özet

PR'larda otomatik olarak çalışacak iki ayrı workflow:

1. **unit-tests.yml** — `npm ci + build + npm test` (~2 dk)
   - Tip kontrolü (`tsc --noEmit` build içinde)
   - Chrome MV3 build (smoke check)
   - Vitest suite (163 test, baseline yeşil)

2. **e2e-tests.yml** — `npm ci + Playwright install + build + xvfb-run npx playwright test` (~5-15 dk)
   - `xvfb-run` ile sanal X display — MV3 eklentisi headless'ta yüklenmediği için fixture `headless: false` kullanıyor
   - `playwright-report` her durumda, `test-results/` (trace + screenshots) sadece hata durumunda artifact olarak yüklenir

Her ikisi de `pull_request` (main'e) + `push` (main'e) tetiklenir. `concurrency` anahtarı aynı ref üzerindeki eski çalışmaları iptal eder.

## Required status check yapma

Settings → Branches → `main` için branch protection rule → Require status checks to pass → şu iki check'i seç:
- `Type check, build, unit tests`
- `Playwright e2e (Chromium + extension)`

**"Do not allow bypassing the above settings"** kapalı bırakılırsa admin'ler bozuk baseline durumunda zorla merge edebilir (istediğin gibi).

## Güvenlik notu

İki workflow da sadece `${{ github.ref }}` interpolasyonu kullanıyor — PR body/title/commit message gibi saldırgan-kontrollü alanları shell'e geçirmiyor.

## Test planı

- [ ] Bu PR'ın kendisinde her iki workflow'un tetiklenip yeşil olduğunu gör
- [ ] Başka bir açık PR'da (örn. #22) aynı workflow'ların otomatik çalışıp sonuç döndürdüğünü gör
- [ ] Required check'leri ayarla (manuel, GitHub Settings)
- [ ] Admin override davranışını doğrula (kırık baseline e2e ile)

## Not

Mevcut main'deki e2e baseline 15/28 FAIL veriyordu (güvenlik PR'ı #22 öncesi tespit edilmişti) — required yapıldığında PR'lar bloke olacak; ya önce baseline temizlenmeli ya da admin bypass kullanılmalı.