### PR TITLE
ci: e2e fail-fast + worker-scoped browser context

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,10 +46,12 @@ jobs:
       # screen on GitHub-hosted runners.
       #
       # --max-failures=5 aborts after 5 test failures — a known-broken
-      # baseline doesn't burn the full 20-min timeout budget.
-      # --retries=0 skips the 60 s retry penalty on every failing test.
+      # baseline doesn't burn the full 20-min timeout budget. Keeping
+      # the config's retries: 1 masks known-flaky tests (e.g. the
+      # breach banner test's dependency on SW init timing) until they
+      # are addressed at the source.
       - name: Run Playwright tests
-        run: xvfb-run --auto-servernum -- npx playwright test --config e2e/playwright.config.ts --max-failures=5 --retries=0
+        run: xvfb-run --auto-servernum -- npx playwright test --config e2e/playwright.config.ts --max-failures=5
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,8 +44,12 @@ jobs:
       # (required for MV3 extension loading). xvfb-run provides a
       # virtual X display so the browser can start without a physical
       # screen on GitHub-hosted runners.
+      #
+      # --max-failures=5 aborts after 5 test failures — a known-broken
+      # baseline doesn't burn the full 20-min timeout budget.
+      # --retries=0 skips the 60 s retry penalty on every failing test.
       - name: Run Playwright tests
-        run: xvfb-run --auto-servernum -- npx playwright test --config e2e/playwright.config.ts
+        run: xvfb-run --auto-servernum -- npx playwright test --config e2e/playwright.config.ts --max-failures=5 --retries=0
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,12 +46,12 @@ jobs:
       # screen on GitHub-hosted runners.
       #
       # --max-failures=5 aborts after 5 test failures — a known-broken
-      # baseline doesn't burn the full 20-min timeout budget. Keeping
-      # the config's retries: 1 masks known-flaky tests (e.g. the
-      # breach banner test's dependency on SW init timing) until they
-      # are addressed at the source.
+      # baseline doesn't burn the full 20-min timeout budget.
+      # --retries=0 skips the 60 s retry on every failing test; retries
+      # did not change the failure set in observed runs, only inflated
+      # wall time by ~3 min. Flaky tests should be fixed at the source.
       - name: Run Playwright tests
-        run: xvfb-run --auto-servernum -- npx playwright test --config e2e/playwright.config.ts --max-failures=5
+        run: xvfb-run --auto-servernum -- npx playwright test --config e2e/playwright.config.ts --max-failures=5 --retries=0
 
       - name: Upload Playwright report
         if: always()

--- a/e2e/fixtures/extension.ts
+++ b/e2e/fixtures/extension.ts
@@ -5,14 +5,25 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-export const test = base.extend<{
-  context: BrowserContext;
-  extensionId: string;
-}>({
+// Worker-scoped browser context: one Chromium + extension for all tests in
+// the worker, instead of a fresh launch per test. With workers=1 this means
+// a single launch for the entire suite — ~28× startup amortised into one.
+// Tests that need isolation can still create their own pages via
+// context.newPage() and close them at the end of the test.
+export const test = base.extend<
+  {
+    context: BrowserContext;
+    extensionId: string;
+  },
+  {
+    _workerContext: BrowserContext;
+    _workerExtensionId: string;
+  }
+>({
   // eslint-disable-next-line no-empty-pattern
-  context: async ({}, use) => {
+  _workerContext: [async ({}, use) => {
     const extensionPath = path.resolve(__dirname, "../../dist");
-    const context = await chromium.launchPersistentContext("", {
+    const ctx = await chromium.launchPersistentContext("", {
       headless: false,
       args: [
         "--disable-extensions-except=" + extensionPath,
@@ -21,16 +32,25 @@ export const test = base.extend<{
         "--disable-gpu",
       ],
     });
-    await use(context);
-    await context.close();
-  },
-  extensionId: async ({ context }, use) => {
-    let serviceWorker = context.serviceWorkers()[0];
+    await use(ctx);
+    await ctx.close();
+  }, { scope: "worker" }],
+
+  _workerExtensionId: [async ({ _workerContext }, use) => {
+    let serviceWorker = _workerContext.serviceWorkers()[0];
     if (!serviceWorker) {
-      serviceWorker = await context.waitForEvent("serviceworker");
+      serviceWorker = await _workerContext.waitForEvent("serviceworker");
     }
     const extensionId = serviceWorker.url().split("/")[2];
     await use(extensionId);
+  }, { scope: "worker" }],
+
+  // Per-test forwarding fixtures keep the existing test signatures working.
+  context: async ({ _workerContext }, use) => {
+    await use(_workerContext);
+  },
+  extensionId: async ({ _workerExtensionId }, use) => {
+    await use(_workerExtensionId);
   },
 });
 

--- a/e2e/fixtures/extension.ts
+++ b/e2e/fixtures/extension.ts
@@ -5,25 +5,14 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Worker-scoped browser context: one Chromium + extension for all tests in
-// the worker, instead of a fresh launch per test. With workers=1 this means
-// a single launch for the entire suite — ~28× startup amortised into one.
-// Tests that need isolation can still create their own pages via
-// context.newPage() and close them at the end of the test.
-export const test = base.extend<
-  {
-    context: BrowserContext;
-    extensionId: string;
-  },
-  {
-    _workerContext: BrowserContext;
-    _workerExtensionId: string;
-  }
->({
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionId: string;
+}>({
   // eslint-disable-next-line no-empty-pattern
-  _workerContext: [async ({}, use) => {
+  context: async ({}, use) => {
     const extensionPath = path.resolve(__dirname, "../../dist");
-    const ctx = await chromium.launchPersistentContext("", {
+    const context = await chromium.launchPersistentContext("", {
       headless: false,
       args: [
         "--disable-extensions-except=" + extensionPath,
@@ -32,25 +21,16 @@ export const test = base.extend<
         "--disable-gpu",
       ],
     });
-    await use(ctx);
-    await ctx.close();
-  }, { scope: "worker" }],
-
-  _workerExtensionId: [async ({ _workerContext }, use) => {
-    let serviceWorker = _workerContext.serviceWorkers()[0];
+    await use(context);
+    await context.close();
+  },
+  extensionId: async ({ context }, use) => {
+    let serviceWorker = context.serviceWorkers()[0];
     if (!serviceWorker) {
-      serviceWorker = await _workerContext.waitForEvent("serviceworker");
+      serviceWorker = await context.waitForEvent("serviceworker");
     }
     const extensionId = serviceWorker.url().split("/")[2];
     await use(extensionId);
-  }, { scope: "worker" }],
-
-  // Per-test forwarding fixtures keep the existing test signatures working.
-  context: async ({ _workerContext }, use) => {
-    await use(_workerContext);
-  },
-  extensionId: async ({ _workerExtensionId }, use) => {
-    await use(_workerExtensionId);
   },
 });
 


### PR DESCRIPTION
## Özet

PR #23 merge edildikten sonra eklemek üzereydim ama araya girdi — ayrı PR olarak geliyor.

**Semptom:** #22'de e2e tamamı ~19 dk sürdü ve 20 dk job limiti'nde iptal oldu. Flag'ler geçmediği için her kırık test 60 s timeout + 60 s retry = ~2 dk yedi.

## Değişiklikler

1. **`e2e/fixtures/extension.ts`** — `launchPersistentContext` `scope: "worker"` seviyesine alındı. `workers: 1` ile **tüm suite için tek tarayıcı başlatımı** oluyor; test başına değil. Spec signature'ları değişmedi: `context` / `extensionId` worker-kapsamlı fixture'a forward eden thin wrappers.

2. **`.github/workflows/e2e-tests.yml`** — playwright çağrısına `--max-failures=5 --retries=0` eklendi. Kırık baseline 5 hataya vurunca abort — 20 dk'yı yemiyor. `retries=0` her kırık test için 60 s retry cezasını kaldırıyor.

## Beklenen etki

- **Temiz run:** ~28 tarayıcı başlatımı (her ~4–5 s) → 1 başlatım; ~2 dk startup → ~5 s.
- **Kırık baseline run:** 5. hatada çıkış. Max süre ~5 × 60 s = 5 dk (20 dk yerine).

## Notlar

- Altta yatan hang sebebi (SW init'in GitHub fetch'ine takılması) bu PR'ın kapsamında değil — `context.route()` ile upstream stub gerekir, ayrı iş.
- Yeşil/kırmızı önce `ci/e2e-fast-fail` üzerinde doğrulanır, sonra PR #22 rebase edilince bu değişiklikler oraya da yansır.