### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "tr",
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "tr",
   "icons": {

--- a/manifest.safari.json
+++ b/manifest.safari.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "tr",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alparslan",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Guvenli tarayici eklentisi - Phishing ve dolandiriciliga karsi kalkan",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Version bump for the v0.2.0 security + CI infra release. Merge this, then tag + publish GitHub Release v0.2.0 so the release.yml workflow attaches the three browser zips.