### PR TITLE
feat: merkezi bir URL canonicalizer eklendi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alparslan",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alparslan",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/src/detector/url-canonicalizer.ts
+++ b/src/detector/url-canonicalizer.ts
@@ -1,0 +1,125 @@
+export type UrlScheme = "http" | "https" | "other";
+
+export interface CanonicalUrl {
+  originalUrl: string;
+  normalizedUrl: string | null;
+  scheme: UrlScheme;
+  hostname: string | null;
+  asciiHostname: string | null;
+  unicodeHostname: string | null;
+  registrableDomain: string | null;
+  publicSuffix: string | null;
+  subdomain: string | null;
+  path: string | null;
+  port: string | null;
+  isIpAddress: boolean;
+  isPrivateIp: boolean;
+  hasCredentials: boolean;
+  hasTrailingDot: boolean;
+  parseError?: string;
+}
+
+function emptyCanonicalUrl(originalUrl: string, parseError: string): CanonicalUrl {
+  return {
+    originalUrl,
+    normalizedUrl: null,
+    scheme: "other",
+    hostname: null,
+    asciiHostname: null,
+    unicodeHostname: null,
+    registrableDomain: null,
+    publicSuffix: null,
+    subdomain: null,
+    path: null,
+    port: null,
+    isIpAddress: false,
+    isPrivateIp: false,
+    hasCredentials: false,
+    hasTrailingDot: false,
+    parseError,
+  };
+}
+
+function getScheme(protocol: string): UrlScheme {
+  if (protocol === "http:") return "http";
+  if (protocol === "https:") return "https";
+  return "other";
+}
+
+function stripTrailingDots(hostname: string): string {
+  return hostname.replace(/\.+$/u, "");
+}
+
+function parseIpv4(hostname: string): number[] | null {
+  const parts = hostname.split(".");
+  if (parts.length !== 4) return null;
+
+  const octets = parts.map((part) => {
+    if (!/^\d+$/u.test(part)) return Number.NaN;
+    if (part.length > 1 && part.startsWith("0")) return Number.NaN;
+    return Number(part);
+  });
+
+  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+    return null;
+  }
+
+  return octets;
+}
+
+function isPrivateIpv4(octets: number[]): boolean {
+  const [a, b] = octets;
+
+  return (
+    a === 10 ||
+    a === 127 ||
+    a === 0 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254)
+  );
+}
+
+function normalizeHref(parsed: URL, normalizedHostname: string | null): string {
+  const normalized = new URL(parsed.href);
+
+  if (normalizedHostname && normalized.hostname !== normalizedHostname) {
+    normalized.hostname = normalizedHostname;
+  }
+
+  return normalized.href;
+}
+
+export function canonicalizeUrl(rawUrl: string): CanonicalUrl {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(rawUrl);
+  } catch (error) {
+    return emptyCanonicalUrl(rawUrl, error instanceof Error ? error.message : "Invalid URL");
+  }
+
+  const rawHostname = parsed.hostname.toLowerCase();
+  const hasTrailingDot = rawHostname.endsWith(".");
+  const hostname = rawHostname ? stripTrailingDots(rawHostname) : null;
+  const ipv4 = hostname ? parseIpv4(hostname) : null;
+  const isIpAddress = ipv4 !== null;
+
+  return {
+    originalUrl: rawUrl,
+    normalizedUrl: normalizeHref(parsed, hostname),
+    scheme: getScheme(parsed.protocol),
+    hostname,
+    asciiHostname: hostname,
+    unicodeHostname: hostname,
+    registrableDomain: null,
+    publicSuffix: null,
+    subdomain: null,
+    path: parsed.pathname,
+    port: parsed.port || null,
+    isIpAddress,
+    isPrivateIp: ipv4 ? isPrivateIpv4(ipv4) : false,
+    hasCredentials: parsed.username.length > 0 || parsed.password.length > 0,
+    hasTrailingDot,
+  };
+}

--- a/tests/detector/url-canonicalizer.test.ts
+++ b/tests/detector/url-canonicalizer.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { canonicalizeUrl } from "@/detector/url-canonicalizer";
+
+describe("canonicalizeUrl", () => {
+  it("normalizes hostname to lowercase", () => {
+    const result = canonicalizeUrl("https://WWW.EXAMPLE.COM/path");
+
+    expect(result.parseError).toBeUndefined();
+    expect(result.scheme).toBe("https");
+    expect(result.hostname).toBe("www.example.com");
+    expect(result.asciiHostname).toBe("www.example.com");
+    expect(result.unicodeHostname).toBe("www.example.com");
+    expect(result.path).toBe("/path");
+  });
+
+  it("removes trailing dots and records that they were present", () => {
+    const result = canonicalizeUrl("https://www.example.com./login");
+
+    expect(result.hostname).toBe("www.example.com");
+    expect(result.hasTrailingDot).toBe(true);
+    expect(result.normalizedUrl).toBe("https://www.example.com/login");
+  });
+
+  it("detects credentials in URLs", () => {
+    const result = canonicalizeUrl("https://user:pass@example.com/account");
+
+    expect(result.hostname).toBe("example.com");
+    expect(result.hasCredentials).toBe(true);
+  });
+
+  it("keeps explicit non-default ports", () => {
+    const result = canonicalizeUrl("https://example.com:8443/path");
+
+    expect(result.port).toBe("8443");
+    expect(result.normalizedUrl).toBe("https://example.com:8443/path");
+  });
+
+  it("normalizes default ports through the URL parser", () => {
+    const result = canonicalizeUrl("https://example.com:443/path");
+
+    expect(result.port).toBeNull();
+    expect(result.normalizedUrl).toBe("https://example.com/path");
+  });
+
+  it("classifies non-http schemes as other", () => {
+    const result = canonicalizeUrl("data:text/html,<h1>test</h1>");
+
+    expect(result.scheme).toBe("other");
+    expect(result.hostname).toBeNull();
+    expect(result.path).toBe("text/html,<h1>test</h1>");
+  });
+
+  it("detects public IPv4 addresses", () => {
+    const result = canonicalizeUrl("http://8.8.8.8/dns");
+
+    expect(result.hostname).toBe("8.8.8.8");
+    expect(result.isIpAddress).toBe(true);
+    expect(result.isPrivateIp).toBe(false);
+  });
+
+  it("detects private IPv4 addresses", () => {
+    const result = canonicalizeUrl("http://192.168.1.10/admin");
+
+    expect(result.hostname).toBe("192.168.1.10");
+    expect(result.isIpAddress).toBe(true);
+    expect(result.isPrivateIp).toBe(true);
+  });
+
+  it("does not treat invalid IPv4-like hostnames as IP addresses", () => {
+    const result = canonicalizeUrl("http://999.999.999.999/path");
+
+    expect(result.parseError).toBeDefined();
+    expect(result.isIpAddress).toBe(false);
+  });
+
+  it("preserves punycode hostnames as ASCII hostnames in the first phase", () => {
+    const result = canonicalizeUrl("https://xn--akbank-3ib.com.tr/");
+
+    expect(result.hostname).toBe("xn--akbank-3ib.com.tr");
+    expect(result.asciiHostname).toBe("xn--akbank-3ib.com.tr");
+    expect(result.unicodeHostname).toBe("xn--akbank-3ib.com.tr");
+  });
+
+  it("returns parseError instead of throwing for invalid URLs", () => {
+    const result = canonicalizeUrl("not-a-url");
+
+    expect(result.normalizedUrl).toBeNull();
+    expect(result.hostname).toBeNull();
+    expect(result.parseError).toBeDefined();
+  });
+
+  it("keeps Public Suffix List fields ready for the next phase", () => {
+    const result = canonicalizeUrl("https://login.akbank.com.tr/");
+
+    expect(result.registrableDomain).toBeNull();
+    expect(result.publicSuffix).toBeNull();
+    expect(result.subdomain).toBeNull();
+  });
+});


### PR DESCRIPTION
  ## Özet                                                                                                                                    
                                                                                                                                             
  URL Identity Foundation çalışmasının ilk adımı olarak merkezi URL canonicalizer altyapısı eklendi.                                         
                                                                                                                                             
  Bu PRda mevcut detector davranışını değiştirmeden ham URL’leri standart bir modele dönüştüren `canonicalizeUrl` fonksiyonunu ekledim. 
Amacı sonraki PR’larda detector, whitelist, blocklist ve breach checker tarafları için ortak bir standart oluşturabilmek.
                                                                                                                                             
  Canonicalizer şu bilgileri çıkarır:                                                                                                        
                                                                                                                                             
  - URL scheme (`http`, `https`, `other`)                                                                                                    
  - Normalize edilmiş hostname                                                                                                               
  - Trailing dot bilgisi                                                                                                                     
  - Explicit port                                                                                                                            
  - Path                                                                                                                                     
  - URL credentials kullanımı                                                                                                                
  - IPv4 tespiti                                                                                                                             
  - Private/local IPv4 tespiti                                                                                                               
  - Invalid URL için `parseError`                                                                                                            
  - Gelecek PSL/eTLD+1 aşaması için hazır alanlar:                                                                                           
    - `registrableDomain`                                                                                                                    
    - `publicSuffix`                                                                                                                         
    - `subdomain`                                                                                                                            
                                                                                                                                             
  Bu PRda bilinçli olarak Public Suffix List hesaplamasını, detector migration’ını ve whitelist/blocklist davranış değişikliklerin kapsam dışı bıraktım (CanonicalUrl tipinde sağlayacakları alankar şu anlık null).                                                                                                                                 
                                                                                                                                             
  ## İlgili Issue                                                                                                                            
                                                                                                                                             
  #33                                                                                                    
                                                                                                                                             
  ## Değişiklikler                                                                                                                           
                                                                                                                                             
  - `src/detector/url-canonicalizer.ts` eklendi                                                                                              
  - `tests/detector/url-canonicalizer.test.ts` eklendi                                                                                       
  - Mevcut `url-checker.ts` davranışı aynı                                                                                                                                                 
                                                                                                                                             
  ## Test sonucu                                                                                                                             
                                                                                                                                             
  Canonicalizer spec seti:                                                                                                                   
                                                                                                                                             
  - 12 test passed                                                                                                                           
  - Hostname lowercase normalization: passed                                                                                                 
  - Trailing dot normalization: passed                                                                                                       
  - Credentials detection: passed                                                                                                            
  - Explicit/default port davranışı: passed                                                                                                  
  - Non-http scheme sınıflandırması: passed                                                                                                  
  - Public/private IPv4 tespiti: passed                                                                                                      
  - Invalid IPv4-like hostname davranışı: passed                                                                                             
  - Invalid URL `parseError` davranışı: passed
  - Punycode hostname placeholder davranışı: passed                                                                                          
  - PSL alanlarının sonraki aşama için hazır olması: passed                                                                                  
                                                                                                                                             
  ## Test planı                                                                                                                              
                                                                                                                                             
  - [x] `npm test -- url-canonicalizer` başarılı                                                                                             
  - [x] `npm test` başarılı                                                                                                                  
  - [x] `npm run build` başarılı                                                                                                             
  - [x] `npx eslint src/detector/url-canonicalizer.ts` başarılı                                                                              
  - [x] Mevcut detector davranışı değiştirilmedi                                                                                             
  - [x] Public Suffix List alanları API’de hazır, ancak bu PR’da hesaplanmıyor                                                               
  - [x] Invalid URL throw etmiyor, `parseError` dönüyor                                                                                      
  - [x] `999.999.999.999` geçerli IP olarak kabul edilmiyor                                                                                  
                                                                                                                                             
  ## Notlar                                                                                                                                  
                                                                                                                                             
  `npm run lint` tüm repo için mevcut lint borçları nedeniyle başarısız oluyor. Hatalar bu PR’da eklenen dosyalardan değil.     
                                                                                                                                             
  Mevcut lint hataları şu dosyalarda:                                                                                                        

  - `src/breach/checker.ts`                                                                                                                  
  - `src/network/dnr-manager.ts`                                                                                                             
  - `src/popup/App.tsx`                                                                                                                      
  - `src/utils/safe-fetch.ts`                                                                                                                
                                                                                                                                                                                                       
 