### PR TITLE
feat: URL canonicalizer'a Public Suffix List desteği eklendi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "alparslan",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alparslan",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "tldts": "^7.4.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -4372,23 +4373,21 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
-      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
-      "dev": true,
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.27"
+        "tldts-core": "^7.4.2"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
-      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
-      "dev": true,
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
       "license": "MIT"
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "tldts": "^7.4.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/src/detector/url-canonicalizer.ts
+++ b/src/detector/url-canonicalizer.ts
@@ -1,3 +1,5 @@
+import { parse as parseTld } from "tldts";
+
 export type UrlScheme = "http" | "https" | "other";
 
 export interface CanonicalUrl {
@@ -90,6 +92,37 @@ function normalizeHref(parsed: URL, normalizedHostname: string | null): string {
   return normalized.href;
 }
 
+function getDomainParts(hostname: string | null, isIpAddress: boolean): Pick<
+  CanonicalUrl,
+  "registrableDomain" | "publicSuffix" | "subdomain"
+> {
+  if (!hostname || isIpAddress) {
+    return { registrableDomain: null, publicSuffix: null, subdomain: null };
+  }
+
+  const parsedDomain = parseTld(hostname, {
+    allowPrivateDomains: true,
+    extractHostname: false,
+  });
+
+  return {
+    registrableDomain: parsedDomain.domain ?? null,
+    publicSuffix: parsedDomain.publicSuffix ?? null,
+    subdomain: parsedDomain.subdomain || null,
+  };
+}
+
+export function isPublicSuffixHostname(hostname: string): boolean {
+  const canonical = canonicalizeUrl(`https://${hostname}`);
+
+  return (
+    canonical.parseError === undefined &&
+    canonical.hostname !== null &&
+    canonical.publicSuffix === canonical.hostname &&
+    canonical.registrableDomain === null
+  );
+}
+
 export function canonicalizeUrl(rawUrl: string): CanonicalUrl {
   let parsed: URL;
 
@@ -104,6 +137,7 @@ export function canonicalizeUrl(rawUrl: string): CanonicalUrl {
   const hostname = rawHostname ? stripTrailingDots(rawHostname) : null;
   const ipv4 = hostname ? parseIpv4(hostname) : null;
   const isIpAddress = ipv4 !== null;
+  const domainParts = getDomainParts(hostname, isIpAddress);
 
   return {
     originalUrl: rawUrl,
@@ -112,9 +146,9 @@ export function canonicalizeUrl(rawUrl: string): CanonicalUrl {
     hostname,
     asciiHostname: hostname,
     unicodeHostname: hostname,
-    registrableDomain: null,
-    publicSuffix: null,
-    subdomain: null,
+    registrableDomain: domainParts.registrableDomain,
+    publicSuffix: domainParts.publicSuffix,
+    subdomain: domainParts.subdomain,
     path: parsed.pathname,
     port: parsed.port || null,
     isIpAddress,

--- a/tests/detector/url-canonicalizer.test.ts
+++ b/tests/detector/url-canonicalizer.test.ts
@@ -89,8 +89,36 @@ describe("canonicalizeUrl", () => {
     expect(result.parseError).toBeDefined();
   });
 
-  it("keeps Public Suffix List fields ready for the next phase", () => {
+  it("computes registrable domain, public suffix, and subdomain for Turkish domains", () => {
     const result = canonicalizeUrl("https://login.akbank.com.tr/");
+
+    expect(result.registrableDomain).toBe("akbank.com.tr");
+    expect(result.publicSuffix).toBe("com.tr");
+    expect(result.subdomain).toBe("login");
+  });
+
+  it("computes registrable domain for multi-label public suffixes", () => {
+    const result = canonicalizeUrl("https://sub.example.co.uk/");
+
+    expect(result.registrableDomain).toBe("example.co.uk");
+    expect(result.publicSuffix).toBe("co.uk");
+    expect(result.subdomain).toBe("sub");
+  });
+
+  it.each([
+    ["https://foo.github.io/", "foo.github.io", "github.io"],
+    ["https://foo.pages.dev/", "foo.pages.dev", "pages.dev"],
+    ["https://foo.blogspot.com/", "foo.blogspot.com", "blogspot.com"],
+  ])("treats private suffixes as public suffix boundaries for %s", (url, domain, suffix) => {
+    const result = canonicalizeUrl(url);
+
+    expect(result.registrableDomain).toBe(domain);
+    expect(result.publicSuffix).toBe(suffix);
+    expect(result.subdomain).toBeNull();
+  });
+
+  it("keeps Public Suffix List fields null for IP addresses", () => {
+    const result = canonicalizeUrl("http://127.0.0.1/");
 
     expect(result.registrableDomain).toBeNull();
     expect(result.publicSuffix).toBeNull();


### PR DESCRIPTION
 ## Özet
                                                                                                   
  Issue #33 kapsamındaki URL Identity Foundation çalışmasının PSL/eTLD+1 adımı eklendi.            
                                                                                                   
  Bu PR mevcut detector davranışını değiştirmeden `canonicalizeUrl()` çıktısındaki null olan Public Suffix  
  List alanlarını dolduruyor.                                            
                                                                                                   
  ## Değişiklikler                                                                                 
                                                                                                   
  - `tldts` runtime dependency olarak eklendi                                                      
  - `canonicalizeUrl()` için PSL/eTLD+1 hesaplaması eklendi                                        
  - `registrableDomain`, `publicSuffix`, `subdomain` alanları dolduruluyor                         
  - Private suffix desteği `allowPrivateDomains: true` ile açık                                    
  - `isPublicSuffixHostname()` helper'ı eklendi                                                    
  - Canonicalizer testleri `com.tr`, `co.uk`, `github.io`, `pages.dev`, `blogspot.com` edge-       
  case'leriyle genişletildi                                                                        
                                                                                                   
  ## İlgili Issue                                                                                  
                                                                                                   
  #33                                                                                              
                                                                                                   
  ## Test planı                                                                                    
                                                                                                   
  - [x] `npm test -- url-canonicalizer url-checker whitelist-normalize list-cache whitelist-       
  helpers` başarılı                                                                                
  - [x] `npm test -- typosquatting-deep detection-effectiveness` başarılı                          
  - [x] `npm test` başarılı                                                                        
  - [x] `npm run build` başarılı                                                                   
                                                                                                                                                                           
                             