### PR TITLE
feat: detector canonical domain modeline geçirildi

### DIFF
--- a/src/detector/url-checker.ts
+++ b/src/detector/url-checker.ts
@@ -4,6 +4,7 @@ import { usomBloomTest } from "@/blocklist/usom-updater";
 import { hasDomain } from "@/blocklist/indexeddb-store";
 import { isDynamicWhitelisted, isUgcDomain, getRiskyTld } from "@/blocklist/whitelist-updater";
 import t from "@/i18n/tr";
+import { canonicalizeUrl } from "@/detector/url-canonicalizer";
 
 // ─── PUNYCODE DECODER (RFC 3492) ─────────────────────────────────
 // Chrome converts IDN domains to punycode (е-devlet.com → xn--devlet-2of.com).
@@ -200,24 +201,34 @@ const TRUSTED_DOMAINS = new Set([
 export { getBlacklistSize as getBlocklistSize } from "@/storage/list-cache";
 
 export function extractDomain(url: string): string | null {
-  try {
-    const parsed = new URL(url);
-    return parsed.hostname.toLowerCase();
-  } catch {
-    return null;
-  }
+  return canonicalizeUrl(url).hostname;
 }
 
 export function extractRootDomain(hostname: string): string {
-  const parts = hostname.split(".");
-  if (parts.length <= 2) return hostname;
+  const canonical = canonicalizeUrl(`https://${hostname}`);
 
-  // Handle .com.tr, .gov.tr, .org.tr etc.
-  const secondLevel = parts[parts.length - 2];
-  if (["com", "gov", "org", "edu", "net", "mil"].includes(secondLevel) && parts.length >= 3) {
-    return parts.slice(-3).join(".");
-  }
-  return parts.slice(-2).join(".");
+  return canonical.registrableDomain ?? canonical.hostname ?? hostname.toLowerCase();
+}
+
+function getRootDomainLabelCount(hostname: string): number {
+  const canonical = canonicalizeUrl(`https://${hostname}`);
+  const root = canonical.registrableDomain ?? canonical.hostname ?? hostname.toLowerCase();
+
+  return root.split(".").length;
+}
+
+function extractRootDomainPreservingLabels(hostname: string): string {
+  const parts = hostname.toLowerCase().split(".");
+  const rootLabelCount = getRootDomainLabelCount(hostname);
+
+  return parts.slice(-rootLabelCount).join(".");
+}
+
+function extractSubdomainPartsPreservingLabels(hostname: string): string[] {
+  const parts = hostname.toLowerCase().split(".");
+  const rootLabelCount = getRootDomainLabelCount(hostname);
+
+  return parts.length > rootLabelCount ? parts.slice(0, -rootLabelCount) : [];
 }
 
 export function levenshteinDistance(a: string, b: string): number {
@@ -324,7 +335,7 @@ export function checkTyposquatting(
 ): { isSuspicious: boolean; similarTo: string | null; reason: string | null } {
   // Decode punycode labels so homoglyph detection works on Unicode chars
   const decoded = decodePunycodeDomain(domain);
-  const root = extractRootDomain(decoded);
+  const root = extractRootDomainPreservingLabels(decoded);
 
   // If the domain itself is trusted, no typosquatting
   if (TRUSTED_DOMAINS.has(root)) {
@@ -344,8 +355,7 @@ export function checkTyposquatting(
   const digNormName = normalizeDigitLetterConfusables(strippedName);
 
   // Check all subdomain parts for trusted name hiding (e.g. garanti.evil.com)
-  const subdomainParts = decoded.split(".");
-  const allParts = subdomainParts.length > 2 ? subdomainParts.slice(0, -2) : [];
+  const allParts = extractSubdomainPartsPreservingLabels(decoded);
 
   for (const trusted of TRUSTED_DOMAINS) {
     const trustedRoot = extractRootDomain(trusted);
@@ -432,7 +442,8 @@ export function checkUrl(
   url: string,
   protectionLevel: ExtensionSettings["protectionLevel"] = "medium",
 ): ThreatResult {
-  const domain = extractDomain(url);
+  const canonical = canonicalizeUrl(url);
+  const domain = canonical.hostname;
   const now = Date.now();
 
   if (!domain) {
@@ -445,7 +456,7 @@ export function checkUrl(
     };
   }
 
-  const rootDomain = extractRootDomain(domain);
+  const rootDomain = canonical.registrableDomain ?? domain;
   const reasons: string[] = [];
   let score = 0;
 
@@ -507,8 +518,8 @@ export function checkUrl(
   }
 
   // Medium + High: excessive subdomain check
-  const subdomainCount = domain.split(".").length;
-  if (subdomainCount > 4) {
+  const subdomainCount = canonical.subdomain ? canonical.subdomain.split(".").length : 0;
+  if (subdomainCount > 3) {
     score += 15;
     reasons.push(t.reasons.excessiveSubdomains);
   }

--- a/src/detector/url-checker.ts
+++ b/src/detector/url-checker.ts
@@ -210,23 +210,31 @@ export function extractRootDomain(hostname: string): string {
   return canonical.registrableDomain ?? canonical.hostname ?? hostname.toLowerCase();
 }
 
-function getRootDomainLabelCount(hostname: string): number {
-  const canonical = canonicalizeUrl(`https://${hostname}`);
+function getRootLabelCountFromCanonical(
+  hostname: string,
+  canonical: ReturnType<typeof canonicalizeUrl>,
+): number {
   const root = canonical.registrableDomain ?? canonical.hostname ?? hostname.toLowerCase();
 
   return root.split(".").length;
 }
 
-function extractRootDomainPreservingLabels(hostname: string): string {
+function extractRootDomainPreservingLabels(
+  hostname: string,
+  canonical: ReturnType<typeof canonicalizeUrl>,
+): string {
   const parts = hostname.toLowerCase().split(".");
-  const rootLabelCount = getRootDomainLabelCount(hostname);
+  const rootLabelCount = getRootLabelCountFromCanonical(hostname, canonical);
 
   return parts.slice(-rootLabelCount).join(".");
 }
 
-function extractSubdomainPartsPreservingLabels(hostname: string): string[] {
+function extractSubdomainPartsPreservingLabels(
+  hostname: string,
+  canonical: ReturnType<typeof canonicalizeUrl>,
+): string[] {
   const parts = hostname.toLowerCase().split(".");
-  const rootLabelCount = getRootDomainLabelCount(hostname);
+  const rootLabelCount = getRootLabelCountFromCanonical(hostname, canonical);
 
   return parts.length > rootLabelCount ? parts.slice(0, -rootLabelCount) : [];
 }
@@ -332,10 +340,11 @@ function extractName(rootDomain: string): string {
 
 export function checkTyposquatting(
   domain: string,
+  canonical?: ReturnType<typeof canonicalizeUrl>,
 ): { isSuspicious: boolean; similarTo: string | null; reason: string | null } {
-  // Decode punycode labels so homoglyph detection works on Unicode chars
   const decoded = decodePunycodeDomain(domain);
-  const root = extractRootDomainPreservingLabels(decoded);
+  const resolvedCanonical = canonical ?? canonicalizeUrl(`https://${decoded}`);
+  const root = extractRootDomainPreservingLabels(decoded, resolvedCanonical);
 
   // If the domain itself is trusted, no typosquatting
   if (TRUSTED_DOMAINS.has(root)) {
@@ -355,7 +364,7 @@ export function checkTyposquatting(
   const digNormName = normalizeDigitLetterConfusables(strippedName);
 
   // Check all subdomain parts for trusted name hiding (e.g. garanti.evil.com)
-  const allParts = extractSubdomainPartsPreservingLabels(decoded);
+  const allParts = extractSubdomainPartsPreservingLabels(decoded, resolvedCanonical);
 
   for (const trusted of TRUSTED_DOMAINS) {
     const trustedRoot = extractRootDomain(trusted);
@@ -488,7 +497,7 @@ export function checkUrl(
   }
 
   // Medium + High: typosquatting check
-  const typo = checkTyposquatting(domain);
+  const typo = checkTyposquatting(domain, canonical);
   if (typo.isSuspicious) {
     const reasonLabels: Record<string, { score: number; text: string }> = {
       "homoglyph": { score: 100, text: t.reasons.homoglyph },

--- a/tests/detector/url-checker.test.ts
+++ b/tests/detector/url-checker.test.ts
@@ -46,6 +46,11 @@ describe("extractRootDomain", () => {
   it("should handle .gov.tr domains", () => {
     expect(extractRootDomain("www.turkiye.gov.tr")).toBe("turkiye.gov.tr");
   });
+
+  it("should handle private suffix domains", () => {
+    expect(extractRootDomain("foo.github.io")).toBe("foo.github.io");
+    expect(extractRootDomain("bar.foo.github.io")).toBe("foo.github.io");
+  });
 });
 
 describe("levenshteinDistance", () => {
@@ -82,6 +87,13 @@ describe("checkTyposquatting", () => {
   it("should not flag completely different domains", () => {
     const result = checkTyposquatting("randomsite.com");
     expect(result.isSuspicious).toBe(false);
+  });
+
+  it("should detect trusted-name hiding across canonical subdomain boundaries", () => {
+    const result = checkTyposquatting("garanti.evil.com");
+
+    expect(result.isSuspicious).toBe(true);
+    expect(result.reason).toBe("subdomain-impersonation");
   });
 });
 

--- a/tests/detector/url-checker.test.ts
+++ b/tests/detector/url-checker.test.ts
@@ -139,9 +139,24 @@ describe("checkUrl", () => {
     expect(result.score).toBeGreaterThanOrEqual(30);
   });
 
-  it("should flag excessive subdomains", () => {
-    const result = checkUrl("https://a.b.c.d.e.example.com");
-    expect(result.reasons.some((r) => r.includes("alt alan"))).toBe(true);
+  describe("excessive subdomain threshold (> 3 labels)", () => {
+    it("3 subdomain labels — must NOT trigger excessive-subdomain warning", () => {
+      // a.b.c  → canonical.subdomain = "a.b.c" → 3 labels, threshold is > 3 → no flag
+      const result = checkUrl("https://a.b.c.example.com");
+      expect(result.reasons.some((r) => r.includes("alt alan"))).toBe(false);
+      expect(result.level).not.toBe(ThreatLevel.SUSPICIOUS);
+    });
+
+    it("4 subdomain labels — must trigger excessive-subdomain warning", () => {
+      // a.b.c.d → canonical.subdomain = "a.b.c.d" → 4 labels, threshold is > 3 → flag
+      const result = checkUrl("https://a.b.c.d.example.com");
+      expect(result.reasons.some((r) => r.includes("alt alan"))).toBe(true);
+    });
+
+    it("5+ subdomain labels — also triggers (existing smoke test)", () => {
+      const result = checkUrl("https://a.b.c.d.e.example.com");
+      expect(result.reasons.some((r) => r.includes("alt alan"))).toBe(true);
+    });
   });
 
   it("should flag suspicious keywords in domain", () => {


### PR DESCRIPTION
## Özet

Issue #33 kapsamındaki detector migration adımı tamamlandı.

Bu PR, url-checker içindeki domain/root-domain ayrıştırma mantığını merkezi canonicalizer modeline geçiriyor. Detector artık URL identity için canonicalizeUrl() çıktısını parametre olarak alıyor

## Değişiklikler

- extractDomain() canonicalizer üzerinden çalışacak hale getirildi
- extractRootDomain() PSL/eTLD+1 modelini kullanacak şekilde güncellendi
- checkUrl() içinde hostname ve registrableDomain canonicalizer çıktısından alınıyor
- checkTyposquatting() canonical domain sınırlarını kullanıyor
- Unicode/homoglyph tespitinde label'lar korunarak PSL boundary kullanılıyor
- Excessive subdomain kontrolü canonical subdomain alanına taşındı
- Detector testlerine private suffix ve canonical subdomain edge-case'leri eklendi

## İlgili Issue

#33

## Test planı

- [x] npm test -- url-canonicalizer url-checker whitelist-normalize list-cache whitelist-helpers başarılı
- [x] npm test -- typosquatting-deep detection-effectiveness başarılı
- [x] npm test başarılı
- [x] npm run build başarılı

## Notlar

Bu PR stacked branch'in parçası o nedenle drafta aldım. PR #35 merge olduktan sonra diffi sadeleştirip ve sadece detector migration değişiklikleri kalacak şekilde review request göndereceğim.