### PR TITLE
feat: whitelist ve blocklist canonical domain modeline geçirildi

### DIFF
--- a/src/blocklist/whitelist-updater.ts
+++ b/src/blocklist/whitelist-updater.ts
@@ -13,6 +13,7 @@ import {
 } from "@/storage/idb";
 import { logger } from "@/utils/logger";
 import { fetchTextWithLimit, FETCH_LIMITS } from "@/utils/safe-fetch";
+import { canonicalizeUrl, isPublicSuffixHostname } from "@/detector/url-canonicalizer";
 
 const GITHUB_BASE = "https://raw.githubusercontent.com/AsabiAlgo/blocklists/main";
 const WHITELIST_URL = `${GITHUB_BASE}/whitelist.txt`;
@@ -55,47 +56,24 @@ export function getDynamicWhitelistSize(): number {
   return whitelistDomains.size;
 }
 
-// Domains that must NEVER appear in the dynamic whitelist. A single
-// entry like "com.tr" or "co.uk" would, combined with list-cache's
-// parent-match behaviour, make every subdomain of that public suffix
-// a whitelisted bypass. We reject them at parse time rather than rely
-// on upstream discipline — the remote list is a supply-chain surface.
-const PUBLIC_SUFFIXES: ReadonlySet<string> = new Set([
-  // Single-label gTLDs / ccTLDs
-  "com", "org", "net", "edu", "gov", "mil", "int", "info", "biz",
-  "tr", "uk", "de", "fr", "jp", "kr", "cn", "ru", "it", "es", "pl",
-  "nl", "be", "at", "ch", "se", "no", "fi", "dk", "br", "au", "ca",
-  "us", "io", "co", "me", "tv", "xyz", "app", "dev",
-  // Compound Turkish public suffixes (most relevant for this project)
-  "com.tr", "net.tr", "org.tr", "edu.tr", "gov.tr", "mil.tr", "bel.tr",
-  "pol.tr", "k12.tr", "tsk.tr", "av.tr", "dr.tr",
-  // Other common compound public suffixes
-  "co.uk", "ac.uk", "gov.uk", "org.uk", "me.uk",
-  "com.au", "net.au", "org.au", "edu.au", "gov.au",
-  "co.jp", "ne.jp", "or.jp", "ac.jp",
-  "co.kr", "or.kr",
-  "co.in", "net.in",
-  "co.za",
-  "com.br", "net.br", "org.br", "gov.br",
-]);
-
-function isPublicSuffix(domain: string): boolean {
-  return PUBLIC_SUFFIXES.has(domain);
+function normalizeDomainEntry(domain: string): string | null {
+  const canonical = canonicalizeUrl(`https://${domain}`);
+  if (!canonical.hostname || !canonical.hostname.includes(".")) return null;
+  if (isPublicSuffixHostname(canonical.hostname)) {
+    logger.warn("Rejected public-suffix whitelist entry:", canonical.hostname);
+    return null;
+  }
+  return canonical.hostname;
 }
 
 function parseDomainList(text: string): string[] {
   return text
     .split("\n")
     .map((line) => line.trim().toLowerCase())
-    .filter((line) => {
-      if (!line || line.startsWith("#")) return false;
-      // At least one dot — single-label "com" is always a public suffix.
-      if (!line.includes(".")) return false;
-      if (isPublicSuffix(line)) {
-        logger.warn("Rejected public-suffix whitelist entry:", line);
-        return false;
-      }
-      return true;
+    .flatMap((line) => {
+      if (!line || line.startsWith("#")) return [];
+      const normalized = normalizeDomainEntry(line);
+      return normalized ? [normalized] : [];
     });
 }
 

--- a/src/popup/whitelist-helpers.ts
+++ b/src/popup/whitelist-helpers.ts
@@ -1,10 +1,4 @@
-// Popup-side whitelist domain helpers.
-//
-// More aggressive than the options-page normaliser (src/utils/whitelist-
-// normalize.ts) because the quick-add UX in the popup should turn
-// "www.example.com" into "example.com" so the whitelist entry matches every
-// subdomain. The options-page normaliser deliberately preserves `www.` for
-// users who type domain entries by hand.
+import { canonicalizeUrl } from "@/detector/url-canonicalizer";
 
 /**
  * Normalise a hostname/URL for the popup's quick-add button:
@@ -14,16 +8,13 @@
  *   - lowercase
  */
 export function normalizeQuickWhitelistDomain(value: string): string {
-  // Lowercase FIRST so the protocol / www stripping below also catches
-  // mixed-case inputs like "HTTPS://WWW.EXAMPLE.COM/". The legacy bundled
-  // popup lowercased only at the end, which silently leaked "www." into
-  // whitelist entries for uppercase pastes.
-  return String(value || "")
-    .trim()
-    .toLowerCase()
-    .replace(/^https?:\/\//, "")
-    .replace(/^www\./, "")
-    .split("/")[0];
+  const input = String(value || "").trim().toLowerCase();
+  if (!input) return "";
+
+  const canonical = canonicalizeUrl(input.includes("://") ? input : `https://${input}`);
+  const hostname = canonical.hostname ?? input.split("/")[0].split("?")[0].split("#")[0];
+
+  return hostname.replace(/^www\./, "");
 }
 
 /**

--- a/src/popup/whitelist-helpers.ts
+++ b/src/popup/whitelist-helpers.ts
@@ -12,7 +12,7 @@ export function normalizeQuickWhitelistDomain(value: string): string {
   if (!input) return "";
 
   const canonical = canonicalizeUrl(input.includes("://") ? input : `https://${input}`);
-  const hostname = canonical.hostname ?? input.split("/")[0].split("?")[0].split("#")[0];
+  const hostname = canonical.hostname ?? input.split("/")[0].split("?")[0].split("#")[0].split(":")[0];
 
   return hostname.replace(/^www\./, "");
 }

--- a/src/storage/list-cache.ts
+++ b/src/storage/list-cache.ts
@@ -137,11 +137,11 @@ async function runMigration(): Promise<void> {
     const settings = result.settings as { whitelist?: string[] } | undefined;
     if (settings?.whitelist?.length) {
       for (const domain of settings.whitelist) {
-          const d = normalizeListDomain(domain);
-          if (d && canMatchListDomain(d) && !whitelistSet.has(d)) {
-            whitelistSet.add(d);
-            await idbAddWhitelist(d, "import");
-          }
+        const d = normalizeListDomain(domain);
+        if (d && canMatchListDomain(d) && !whitelistSet.has(d)) {
+          whitelistSet.add(d);
+          await idbAddWhitelist(d, "import");
+        }
       }
       logger.debug(`Migrated ${settings.whitelist.length} whitelist entries`);
     }

--- a/src/storage/list-cache.ts
+++ b/src/storage/list-cache.ts
@@ -11,10 +11,23 @@ import {
   getMetadata,
   setMetadata,
 } from "./idb";
+import { canonicalizeUrl, isPublicSuffixHostname } from "@/detector/url-canonicalizer";
 
 let whitelistSet = new Set<string>();
 let blacklistSet = new Set<string>();
 let cacheReady = false;
+
+function normalizeListDomain(domain: string): string | null {
+  const value = String(domain || "").trim().toLowerCase();
+  if (!value) return null;
+
+  const canonical = canonicalizeUrl(value.includes("://") ? value : `https://${value}`);
+  return canonical.hostname;
+}
+
+function canMatchListDomain(domain: string): boolean {
+  return domain.includes(".") && !isPublicSuffixHostname(domain);
+}
 
 export function isCacheReady(): boolean {
   return cacheReady;
@@ -23,7 +36,8 @@ export function isCacheReady(): boolean {
 // --- Sync lookups (O(1), used on hot path) ---
 
 export function isWhitelisted(domain: string): boolean {
-  const d = domain.toLowerCase();
+  const d = normalizeListDomain(domain);
+  if (!d) return false;
   if (whitelistSet.has(d)) return true;
   // Parent-domain match, capped at 3 labels. A whitelist entry must be
   // a full host name with at least one dot — never a bare TLD or a
@@ -34,18 +48,22 @@ export function isWhitelisted(domain: string): boolean {
   for (let i = 1; i < parts.length - 1; i++) {
     const candidate = parts.slice(i).join(".");
     if (candidate.split(".").length < 2) break;
+    if (!canMatchListDomain(candidate)) continue;
     if (whitelistSet.has(candidate)) return true;
   }
   return false;
 }
 
 export function isBlacklisted(domain: string): boolean {
-  const d = domain.toLowerCase();
+  const d = normalizeListDomain(domain);
+  if (!d) return false;
   if (blacklistSet.has(d)) return true;
   // Check root domain
   const parts = d.split(".");
   for (let i = 1; i < parts.length - 1; i++) {
-    if (blacklistSet.has(parts.slice(i).join("."))) return true;
+    const candidate = parts.slice(i).join(".");
+    if (!canMatchListDomain(candidate)) continue;
+    if (blacklistSet.has(candidate)) return true;
   }
   return false;
 }
@@ -53,31 +71,42 @@ export function isBlacklisted(domain: string): boolean {
 // --- Write-through mutations ---
 
 export async function addToWhitelist(domain: string): Promise<void> {
-  const d = domain.toLowerCase();
+  const d = normalizeListDomain(domain);
+  if (!d || !canMatchListDomain(d)) return;
   whitelistSet.add(d);
   await idbAddWhitelist(d, "user");
 }
 
 export async function removeFromWhitelist(domain: string): Promise<void> {
-  const d = domain.toLowerCase();
+  const d = normalizeListDomain(domain);
+  if (!d) return;
   whitelistSet.delete(d);
   await idbRemoveWhitelist(d);
 }
 
 export async function addToBlacklist(entries: BlacklistEntry[]): Promise<void> {
+  const normalizedEntries: BlacklistEntry[] = [];
   for (const entry of entries) {
-    blacklistSet.add(entry.domain.toLowerCase());
+    const domain = normalizeListDomain(entry.domain);
+    if (!domain || !canMatchListDomain(domain)) continue;
+    blacklistSet.add(domain);
+    normalizedEntries.push({ ...entry, domain });
   }
-  await idbAddBlacklist(entries);
+  await idbAddBlacklist(normalizedEntries);
 }
 
 export async function replaceBlacklistCache(entries: BlacklistEntry[]): Promise<void> {
-  blacklistSet = new Set(entries.map((e) => e.domain.toLowerCase()));
-  await idbReplaceBlacklist(entries);
+  const normalizedEntries = entries.flatMap((entry) => {
+    const domain = normalizeListDomain(entry.domain);
+    return domain && canMatchListDomain(domain) ? [{ ...entry, domain }] : [];
+  });
+  blacklistSet = new Set(normalizedEntries.map((e) => e.domain));
+  await idbReplaceBlacklist(normalizedEntries);
 }
 
 export async function removeFromBlacklist(domain: string): Promise<void> {
-  const d = domain.toLowerCase();
+  const d = normalizeListDomain(domain);
+  if (!d) return;
   blacklistSet.delete(d);
   await idbRemoveBlacklist(d);
 }
@@ -108,11 +137,11 @@ async function runMigration(): Promise<void> {
     const settings = result.settings as { whitelist?: string[] } | undefined;
     if (settings?.whitelist?.length) {
       for (const domain of settings.whitelist) {
-        const d = domain.toLowerCase();
-        if (!whitelistSet.has(d)) {
-          whitelistSet.add(d);
-          await idbAddWhitelist(d, "import");
-        }
+          const d = normalizeListDomain(domain);
+          if (d && canMatchListDomain(d) && !whitelistSet.has(d)) {
+            whitelistSet.add(d);
+            await idbAddWhitelist(d, "import");
+          }
       }
       logger.debug(`Migrated ${settings.whitelist.length} whitelist entries`);
     }
@@ -126,11 +155,11 @@ async function runMigration(): Promise<void> {
     const data = await response.json() as { domains: BlacklistEntry[] };
     if (data.domains?.length) {
       const entries: BlacklistEntry[] = data.domains.map((d) => ({
-        domain: d.domain.toLowerCase(),
+        domain: normalizeListDomain(d.domain) ?? "",
         category: d.category || "other",
         addedAt: d.addedAt || new Date().toISOString().split("T")[0],
         source: d.source || "builtin",
-      }));
+      })).filter((entry) => entry.domain && canMatchListDomain(entry.domain));
       await idbAddBlacklist(entries);
       for (const entry of entries) {
         blacklistSet.add(entry.domain);
@@ -154,8 +183,16 @@ export async function initListCache(): Promise<void> {
     // Load from IndexedDB into memory
     const [whitelist, blacklist] = await Promise.all([getAllWhitelist(), getAllBlacklist()]);
 
-    whitelistSet = new Set(whitelist.map((e) => e.domain));
-    blacklistSet = new Set(blacklist.map((e) => e.domain));
+    whitelistSet = new Set(
+      whitelist
+        .map((e) => normalizeListDomain(e.domain))
+        .filter((domain): domain is string => domain !== null && canMatchListDomain(domain)),
+    );
+    blacklistSet = new Set(
+      blacklist
+        .map((e) => normalizeListDomain(e.domain))
+        .filter((domain): domain is string => domain !== null && canMatchListDomain(domain)),
+    );
 
     // Run migration if needed (first time after update)
     await runMigration();

--- a/src/utils/whitelist-normalize.ts
+++ b/src/utils/whitelist-normalize.ts
@@ -1,14 +1,4 @@
-// Public suffixes that, if allowed as whitelist entries, would disable
-// protection for entire TLDs via the list-cache parent-match rule.
-// Kept intentionally short — the list-cache parent-match is already
-// restricted; this is a UX guard that tells the user "don't do that".
-const REJECTED_SUFFIXES: ReadonlySet<string> = new Set([
-  "com", "org", "net", "edu", "gov", "mil", "int", "info", "biz",
-  "tr", "uk", "de", "fr", "jp", "kr", "cn", "ru", "it", "es",
-  "nl", "be", "io", "co", "me", "xyz", "app", "dev",
-  "com.tr", "net.tr", "org.tr", "edu.tr", "gov.tr", "mil.tr",
-  "co.uk", "ac.uk", "gov.uk",
-]);
+import { canonicalizeUrl, isPublicSuffixHostname } from "@/detector/url-canonicalizer";
 
 /**
  * Normalise a user-typed whitelist entry:
@@ -22,24 +12,21 @@ const REJECTED_SUFFIXES: ReadonlySet<string> = new Set([
 export function normalizeWhitelistInput(raw: string): string {
   const trimmed = raw.trim().toLowerCase();
   if (!trimmed) return "";
+
   let host = trimmed;
-  // If user pasted a full URL, parse it.
   if (host.includes("://")) {
-    try {
-      host = new URL(host).hostname;
-    } catch {
-      return "";
-    }
+    const canonical = canonicalizeUrl(host);
+    host = canonical.hostname ?? "";
   } else {
-    // Strip any path / query / fragment if they typed "example.com/foo".
     host = host.split("/")[0].split("?")[0].split("#")[0];
   }
-  // Strip port.
+
   host = host.split(":")[0];
-  // Strip leading dots and "*." wildcard prefixes. www is preserved
-  // intentionally — some sites only serve on the www subdomain.
   host = host.replace(/^(\*\.|\.)+/, "");
-  if (!host.includes(".")) return ""; // bare TLD / single label
-  if (REJECTED_SUFFIXES.has(host)) return ""; // public suffix
-  return host;
+
+  const canonical = canonicalizeUrl(`https://${host}`);
+  if (!canonical.hostname || !canonical.hostname.includes(".")) return "";
+  if (isPublicSuffixHostname(canonical.hostname)) return "";
+
+  return canonical.hostname;
 }

--- a/tests/storage/list-cache.test.ts
+++ b/tests/storage/list-cache.test.ts
@@ -71,6 +71,20 @@ describe("isWhitelisted", () => {
   it("is case-insensitive", () => {
     expect(isWhitelisted("EXAMPLE.COM")).toBe(true);
   });
+
+  it("matches subdomains under private-suffix registrable domains only", async () => {
+    await addToWhitelist("foo.github.io");
+
+    expect(isWhitelisted("bar.foo.github.io")).toBe(true);
+    expect(isWhitelisted("evil.github.io")).toBe(false);
+  });
+
+  it("ignores public suffix whitelist entries", async () => {
+    await addToWhitelist("github.io");
+
+    expect(isWhitelisted("evil.github.io")).toBe(false);
+    expect(getWhitelistDomains()).not.toContain("github.io");
+  });
 });
 
 describe("isBlacklisted", () => {

--- a/tests/utils/whitelist-normalize.test.ts
+++ b/tests/utils/whitelist-normalize.test.ts
@@ -62,6 +62,9 @@ describe("normalizeWhitelistInput", () => {
       ["com.tr"],    // compound public suffix
       ["co.uk"],
       ["gov.tr"],
+      ["github.io"],
+      ["pages.dev"],
+      ["blogspot.com"],
       ["https://co.uk/"],   // URL-shaped public suffix
       ["http://"],   // malformed URL
       ["://"],
@@ -69,6 +72,16 @@ describe("normalizeWhitelistInput", () => {
       ["..."],
     ])("%s → empty", (input) => {
       expect(normalizeWhitelistInput(input)).toBe("");
+    });
+  });
+
+  describe("allows private-suffix registrable domains", () => {
+    it.each([
+      ["foo.github.io", "foo.github.io"],
+      ["https://foo.pages.dev/path", "foo.pages.dev"],
+      ["foo.blogspot.com", "foo.blogspot.com"],
+    ])("%s → %s", (input, expected) => {
+      expect(normalizeWhitelistInput(input)).toBe(expected);
     });
   });
 });


### PR DESCRIPTION
## Özet

Issue #33 kapsamındaki whitelist/blocklist migration adımı tamamlandı.
Regression testler dışında fonksiyon implementasyonlarıyla ilgili son pr

Bu PR kullanıcı whitelist input'u, dynamic whitelist parsing ve list-cache matching davranışını canonical domain modeline taşıyor. Bunu public suffix whitelist bypass riskini azaltmak ve PSL/private suffix edge-case'lerinde doğru domain sınırlarıyla eşleştirebilmek için ekledik.

## Değişiklikler

- Options whitelist normalizasyonu canonicalizer tabanlı hale getirildi
- Popup quick whitelist normalizasyonu canonicalizer tabanlı hale getirildi
- Dynamic whitelist parser'daki elle public suffix listesi kaldırıldı
- Public suffix reject kararı isPublicSuffixHostname() helper'ına taşındı
- list-cache whitelist/blocklist lookup canonical hostname ile çalışacak şekilde güncellendi
- Parent-domain matching public suffix sınırına kadar çıkmayacak şekilde korundu
- github.io, pages.dev, blogspot.com gibi private suffix edge-case'leri test edildi

## İlgili Issue

#33

## Test planı

- [x] npm test -- url-canonicalizer url-checker whitelist-normalize list-cache whitelist-helpers başarılı
- [x] npm test -- typosquatting-deep detection-effectiveness başarılı
- [x] npm test başarılı
- [x] npm run build başarılı

## Notlar

Bu PR stacked branch'in  son parçası o nedenle draftta. PR #35 merge olduktan sonra diffi sadeleştirip son parçası kalacak şekilde review request göndereceğim.