### PR TITLE
test: Canonicalization için regression corpus eklendi

### DIFF
--- a/tests/detector/url-canonicalizer.test.ts
+++ b/tests/detector/url-canonicalizer.test.ts
@@ -70,6 +70,7 @@ describe("canonicalizeUrl", () => {
     ["http://127.0.0.1/", "127.0.0.1"],
     ["http://10.0.0.5/", "10.0.0.5"],
     ["http://172.16.0.1/", "172.16.0.1"],
+    ["http://192.168.1.1/", "192.168.1.1"],
     ["http://169.254.10.20/", "169.254.10.20"],
   ])("detects private or local IPv4 ranges for %s", (url, hostname) => {
     const result = canonicalizeUrl(url);

--- a/tests/detector/url-canonicalizer.test.ts
+++ b/tests/detector/url-canonicalizer.test.ts
@@ -66,6 +66,20 @@ describe("canonicalizeUrl", () => {
     expect(result.isPrivateIp).toBe(true);
   });
 
+  it.each([
+    ["http://127.0.0.1/", "127.0.0.1"],
+    ["http://10.0.0.5/", "10.0.0.5"],
+    ["http://172.16.0.1/", "172.16.0.1"],
+    ["http://169.254.10.20/", "169.254.10.20"],
+  ])("detects private or local IPv4 ranges for %s", (url, hostname) => {
+    const result = canonicalizeUrl(url);
+
+    expect(result.hostname).toBe(hostname);
+    expect(result.isIpAddress).toBe(true);
+    expect(result.isPrivateIp).toBe(true);
+    expect(result.registrableDomain).toBeNull();
+  });
+
   it("does not treat invalid IPv4-like hostnames as IP addresses", () => {
     const result = canonicalizeUrl("http://999.999.999.999/path");
 
@@ -89,6 +103,18 @@ describe("canonicalizeUrl", () => {
     expect(result.parseError).toBeDefined();
   });
 
+  it.each([
+    ["not-a-url"],
+    ["http://"],
+    ["https://exa mple.com"],
+  ])("keeps invalid URL examples in the parseError path for %s", (url) => {
+    const result = canonicalizeUrl(url);
+
+    expect(result.normalizedUrl).toBeNull();
+    expect(result.hostname).toBeNull();
+    expect(result.parseError).toBeDefined();
+  });
+
   it("computes registrable domain, public suffix, and subdomain for Turkish domains", () => {
     const result = canonicalizeUrl("https://login.akbank.com.tr/");
 
@@ -103,6 +129,27 @@ describe("canonicalizeUrl", () => {
     expect(result.registrableDomain).toBe("example.co.uk");
     expect(result.publicSuffix).toBe("co.uk");
     expect(result.subdomain).toBe("sub");
+  });
+
+  it("keeps phishing brand labels outside the registrable domain when they are only subdomains", () => {
+    const result = canonicalizeUrl("https://akbank.com.tr.evil.com/path");
+
+    expect(result.hostname).toBe("akbank.com.tr.evil.com");
+    expect(result.registrableDomain).toBe("evil.com");
+    expect(result.publicSuffix).toBe("com");
+    expect(result.subdomain).toBe("akbank.com.tr");
+  });
+
+  it.each([
+    ["https://www.example.com./", "www.example.com", true],
+    ["https://user:pass@example.com/", "example.com", false],
+    ["https://login.akbank.com.tr/path", "login.akbank.com.tr", false],
+  ])("records canonical URL security flags for %s", (url, hostname, trailingDot) => {
+    const result = canonicalizeUrl(url);
+
+    expect(result.hostname).toBe(hostname);
+    expect(result.hasTrailingDot).toBe(trailingDot);
+    expect(result.hasCredentials).toBe(url.includes("user:pass"));
   });
 
   it.each([

--- a/tests/detector/url-checker.test.ts
+++ b/tests/detector/url-checker.test.ts
@@ -165,15 +165,34 @@ describe("checkUrl", () => {
   });
 
   it.each([
-    ["https://akbank.com.tr.evil.com/login", ThreatLevel.SUSPICIOUS, 55],
-    ["https://login-akbank.com/", ThreatLevel.DANGEROUS, 70],
-    ["https://akbank-secure.com/", ThreatLevel.DANGEROUS, 70],
-  ])("should flag regression corpus phishing URL %s", (url, level, score) => {
-    const result = checkUrl(url);
+    [
+      "https://akbank.com.tr.evil.com/login",
+      ThreatLevel.SUSPICIOUS,
+      55,
+      t.reasons.subdomainTyposquat, // "alt alan adında benzer isim"
+    ],
+    [
+      "https://login-akbank.com/",
+      ThreatLevel.DANGEROUS,
+      70,
+      t.reasons.containsTrusted, // "güvenilir ismi içeriyor"
+    ],
+    [
+      "https://akbank-secure.com/",
+      ThreatLevel.DANGEROUS,
+      70,
+      t.reasons.containsTrusted, // "güvenilir ismi içeriyor"
+    ],
+  ])(
+    "should flag regression corpus phishing URL %s",
+    (url, level, score, reasonFragment) => {
+      const result = checkUrl(url);
 
-    expect(result.level).toBe(level);
-    expect(result.score).toBeGreaterThanOrEqual(score);
-  });
+      expect(result.level).toBe(level);
+      expect(result.score).toBeGreaterThanOrEqual(score);
+      expect(result.reasons.some((r) => r.includes(reasonFragment))).toBe(true);
+    },
+  );
 
   it("should include timestamp in result", () => {
     const before = Date.now();

--- a/tests/detector/url-checker.test.ts
+++ b/tests/detector/url-checker.test.ts
@@ -51,6 +51,10 @@ describe("extractRootDomain", () => {
     expect(extractRootDomain("foo.github.io")).toBe("foo.github.io");
     expect(extractRootDomain("bar.foo.github.io")).toBe("foo.github.io");
   });
+
+  it("should keep brand-looking labels outside the registrable domain", () => {
+    expect(extractRootDomain("akbank.com.tr.evil.com")).toBe("evil.com");
+  });
 });
 
 describe("levenshteinDistance", () => {
@@ -94,6 +98,24 @@ describe("checkTyposquatting", () => {
 
     expect(result.isSuspicious).toBe(true);
     expect(result.reason).toBe("subdomain-impersonation");
+  });
+
+  it.each([
+    ["akbank.com.tr.evil.com", "isbank.com.tr", "subdomain-typosquat"],
+    ["login-akbank.com", "akbank.com.tr", "contains-trusted-name"],
+    ["akbank-secure.com", "akbank.com.tr", "contains-trusted-name"],
+  ])("detects canonicalization regression corpus sample %s", (domain, similarTo, reason) => {
+    const result = checkTyposquatting(domain);
+
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe(similarTo);
+    expect(result.reason).toBe(reason);
+  });
+
+  it("does not let sibling private-suffix tenants inherit each other's trust", () => {
+    const result = checkTyposquatting("evil.github.io");
+
+    expect(result.isSuspicious).toBe(false);
   });
 });
 
@@ -147,6 +169,17 @@ describe("checkUrl", () => {
   it("should flag suspicious keywords in domain", () => {
     const result = checkUrl("https://secure-login-verify.xyz");
     expect(result.reasons.some((r) => r.includes("anahtar kelime"))).toBe(true);
+  });
+
+  it.each([
+    ["https://akbank.com.tr.evil.com/login", ThreatLevel.SUSPICIOUS, 55],
+    ["https://login-akbank.com/", ThreatLevel.DANGEROUS, 70],
+    ["https://akbank-secure.com/", ThreatLevel.DANGEROUS, 70],
+  ])("should flag regression corpus phishing URL %s", (url, level, score) => {
+    const result = checkUrl(url);
+
+    expect(result.level).toBe(level);
+    expect(result.score).toBeGreaterThanOrEqual(score);
   });
 
   it("should include timestamp in result", () => {

--- a/tests/popup/whitelist-helpers.test.ts
+++ b/tests/popup/whitelist-helpers.test.ts
@@ -24,6 +24,7 @@ describe("normalizeQuickWhitelistDomain", () => {
       ["https://example.com", "example.com"],
       ["https://www.example.com", "example.com"],
       ["https://www.example.com/", "example.com"],
+      ["https://www.example.com:8443/login?token=abc", "example.com"],
     ])("%s → %s", (input, expected) => {
       expect(normalizeQuickWhitelistDomain(input)).toBe(expected);
     });
@@ -78,6 +79,10 @@ describe("normalizeQuickWhitelistDomain", () => {
       expect(normalizeQuickWhitelistDomain("www.akbank.com.tr")).toBe("akbank.com.tr");
     });
 
+    it("preserves private-suffix registrable domains after URL parsing", () => {
+      expect(normalizeQuickWhitelistDomain("https://foo.github.io/path")).toBe("foo.github.io");
+    });
+
     it("only strips the FIRST www, leaves www in middle of host", () => {
       // Pathological but defensive: an attacker can't sneak a bare host past
       // us by embedding "www." mid-string.
@@ -110,6 +115,11 @@ describe("isDomainInWhitelist", () => {
 
     it("matches multi-segment TLD subdomain", () => {
       expect(isDomainInWhitelist("mobile.akbank.com.tr", ["akbank.com.tr"])).toBe(true);
+    });
+
+    it("matches only within the same private-suffix registrable domain", () => {
+      expect(isDomainInWhitelist("bar.foo.github.io", ["foo.github.io"])).toBe(true);
+      expect(isDomainInWhitelist("evil.github.io", ["foo.github.io"])).toBe(false);
     });
   });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,6 @@
 // Vitest setup - mock Chrome APIs
 import "fake-indexeddb/auto";
+import { vi } from "vitest";
 
 const chromeMock = {
   runtime: {
@@ -49,5 +50,27 @@ const chromeMock = {
 
 Object.defineProperty(globalThis, "chrome", {
   value: chromeMock,
+  writable: true,
+});
+
+const originalFetch = globalThis.fetch?.bind(globalThis);
+
+Object.defineProperty(globalThis, "fetch", {
+  value: vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+
+    if (url === "chrome-extension://mock-id/lists/tr-phishing.json") {
+      return Promise.resolve(
+        new Response(JSON.stringify({ domains: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }
+
+    return originalFetch
+      ? originalFetch(input, init)
+      : Promise.reject(new Error(`Unhandled fetch in test setup: ${url}`));
+  }),
   writable: true,
 });

--- a/tests/storage/list-cache.test.ts
+++ b/tests/storage/list-cache.test.ts
@@ -72,6 +72,13 @@ describe("isWhitelisted", () => {
     expect(isWhitelisted("EXAMPLE.COM")).toBe(true);
   });
 
+  it("normalizes URL-shaped whitelist entries before matching", async () => {
+    await addToWhitelist("https://www.example.com:8443/login?token=abc");
+
+    expect(isWhitelisted("www.example.com")).toBe(true);
+    expect(getWhitelistDomains()).toContain("www.example.com");
+  });
+
   it("matches subdomains under private-suffix registrable domains only", async () => {
     await addToWhitelist("foo.github.io");
 
@@ -79,12 +86,15 @@ describe("isWhitelisted", () => {
     expect(isWhitelisted("evil.github.io")).toBe(false);
   });
 
-  it("ignores public suffix whitelist entries", async () => {
-    await addToWhitelist("github.io");
+  it.each(["github.io", "pages.dev", "blogspot.com", "com.tr", "co.uk"])(
+    "ignores public suffix whitelist entry %s",
+    async (domain) => {
+      await addToWhitelist(domain);
 
-    expect(isWhitelisted("evil.github.io")).toBe(false);
-    expect(getWhitelistDomains()).not.toContain("github.io");
-  });
+      expect(isWhitelisted(`evil.${domain}`)).toBe(false);
+      expect(getWhitelistDomains()).not.toContain(domain);
+    },
+  );
 });
 
 describe("isBlacklisted", () => {
@@ -103,6 +113,29 @@ describe("isBlacklisted", () => {
 
   it("returns false for unrelated domain", () => {
     expect(isBlacklisted("safe.com")).toBe(false);
+  });
+
+  it("normalizes URL-shaped blacklist entries before matching", async () => {
+    await addToBlacklist([
+      {
+        domain: "https://login.phish.com:8443/account?token=abc",
+        category: "other",
+        addedAt: "2026-01-01",
+        source: "manual",
+      },
+    ]);
+
+    expect(isBlacklisted("login.phish.com")).toBe(true);
+    expect(isBlacklisted("safe.com")).toBe(false);
+  });
+
+  it("does not overmatch sibling private-suffix tenants", async () => {
+    await addToBlacklist([
+      { domain: "foo.github.io", category: "other", addedAt: "2026-01-01", source: "manual" },
+    ]);
+
+    expect(isBlacklisted("bar.foo.github.io")).toBe(true);
+    expect(isBlacklisted("evil.github.io")).toBe(false);
   });
 });
 

--- a/tests/utils/whitelist-normalize.test.ts
+++ b/tests/utils/whitelist-normalize.test.ts
@@ -26,6 +26,8 @@ describe("normalizeWhitelistInput", () => {
       ["https://example.com?q=1", "example.com"],
       ["https://example.com#section", "example.com"],
       ["https://www.example.com/login?token=abc", "www.example.com"],
+      ["https://www.example.com:8443/login?token=abc", "www.example.com"],
+      ["https://login.akbank.com.tr/path", "login.akbank.com.tr"],
     ])("%s → %s", (input, expected) => {
       expect(normalizeWhitelistInput(input)).toBe(expected);
     });
@@ -65,6 +67,9 @@ describe("normalizeWhitelistInput", () => {
       ["github.io"],
       ["pages.dev"],
       ["blogspot.com"],
+      ["https://github.io/"],
+      ["https://pages.dev/"],
+      ["https://blogspot.com/"],
       ["https://co.uk/"],   // URL-shaped public suffix
       ["http://"],   // malformed URL
       ["://"],
@@ -80,6 +85,7 @@ describe("normalizeWhitelistInput", () => {
       ["foo.github.io", "foo.github.io"],
       ["https://foo.pages.dev/path", "foo.pages.dev"],
       ["foo.blogspot.com", "foo.blogspot.com"],
+      ["bar.foo.github.io", "bar.foo.github.io"],
     ])("%s → %s", (input, expected) => {
       expect(normalizeWhitelistInput(input)).toBe(expected);
     });


### PR DESCRIPTION
  ## Özet                                                                                                           
                                                                                                                    
  Issue #33 kapsamındaki son regression corpus adımı eklendi.                                                       
                                                                                                                    
  Bu PRda runtime davranışı değiştirmeden URL identity foundation hattını unit/regression testlerle kapatıyor.        
  Overengineering olacağını düşünerek e2e test eklemedim.                                             
                                                                                                                    
  ## Değişiklikler                                                                                                  
                                                                                                                    
  - Canonicalizer test corpus'u private/local IP, invalid URL, credentials/trailing-dot, Turkish domain, multi-label
  public suffix ve brand-label subdomain örnekleriyle genişletildi                                                  
  - Detector testleri `akbank.com.tr.evil.com`, `login-akbank.com`, `akbank-secure.com` ve private suffix sibling   
  overmatch regresyonlarını kapsıyor                                                                                
  - Whitelist/blocklist cache testleri URL-shaped input normalization, public suffix reject ve private suffix tenant
  boundary senaryolarını doğruluyor                                                                                 
  - Options/popup whitelist normalizasyon testleri URL-shaped ve private suffix örnekleriyle genişletildi           
  - Vitest setup'ta extension bundled phishing list fetch'i deterministik boş listeye mocklandı                     
                                                                                                                    
  ## İlgili Issue                                                                                                   
                                                                                                                    
  #33                                                                                                          
                                                                                                                    
  ## Test planı                                                                                                     
                                                                                                                    
  - [x] `npm test -- --run tests/detector/url-canonicalizer.test.ts tests/detector/url-checker.test.ts 
     tests/storage/list-cache.test.ts tests/utils/whitelist-normalize.test.ts tests/popup/whitelist-helpers.test.ts` başarılı
  — 169 test                                                                                                        
  - [x] `npm test` başarılı                                                                                         
  - [x] `npm run build` başarılı                                                                                    
                                                                                                                    
  ## Notlar                                                                                                         
                                                                                                                    
  Bu PR #35, #36 ve #37 üstüne gelen stacked serinin son parçası. Bu testlerle birlike Issue #33 kapatılabilir.