### PR TITLE
fix: Detection algoritması değişiklikleri, false positive azaltma

### DIFF
--- a/src/detector/url-checker.ts
+++ b/src/detector/url-checker.ts
@@ -126,10 +126,24 @@ const BRAND_SUBDOMAINS: ReadonlySet<string> = new Set([
   "cloudflarestream.com",
 ]);
 
-const SUSPICIOUS_KEYWORDS: ReadonlyArray<string> = [
-  "giris", "dogrulama", "hesap", "odeme", "sifre", "parola", "aktivasyon", "indirim", "online",
+// Credential/payment-theft signals — strong indicator of phishing intent.
+// Used to flag contains-trusted-name hits for ALL brand tiers.
+const HIGH_RISK_KEYWORDS: ReadonlyArray<string> = [
+  "giris", "dogrulama", "hesap", "odeme", "sifre", "parola", "aktivasyon", "online",
   "login", "secure", "verify", "auth", "signin", "banking", "payment",
 ];
+
+// Generic promotional word — meaningful only alongside a GENERIC brand
+// (google, paypal, microsoft …) or as a minor free-domain score bump.
+// NOT strong enough to flag a DEFAULT brand like garanti or akbank alone:
+// legitimate discount-portal domains (garantiliindirim.com, akbankindirim.com)
+// legitimately contain this word without phishing intent.
+const LOW_RISK_KEYWORDS: ReadonlyArray<string> = [
+  "indirim",
+];
+
+// Combined set — used by the free-domain keyword score path (+20).
+const SUSPICIOUS_KEYWORDS: ReadonlyArray<string> = [...HIGH_RISK_KEYWORDS, ...LOW_RISK_KEYWORDS];
 
 const GENERIC_BRAND_NAMES: ReadonlySet<string> = new Set([
   "turkiye", "google", "microsoft", "apple", "amazon",
@@ -423,14 +437,21 @@ export function checkTyposquatting(
 
     if (strippedTrustedName.length >= 5 && strippedName.length > strippedTrustedName.length) {
       if (strippedName.includes(strippedTrustedName)) {
-        const hasKeyword = SUSPICIOUS_KEYWORDS.some((kw) => strippedName.includes(kw));
+        const hasHighRiskKeyword = HIGH_RISK_KEYWORDS.some((kw) => strippedName.includes(kw));
+        const hasAnyKeyword = SUSPICIOUS_KEYWORDS.some((kw) => strippedName.includes(kw));
         const hasSeparator = rawName.includes("-");
         const ratio = strippedName.length / strippedTrustedName.length;
         const isGeneric = GENERIC_BRAND_NAMES.has(strippedTrustedName);
 
+        // GENERIC brands (google, paypal …): any keyword or separator is
+        // suspicious when the domain isn't too long (ratio < 2.0).
+        // DEFAULT brands (garanti, akbank …): only HIGH-RISK keywords
+        // (credential/payment-oriented) or a separator warrant flagging —
+        // LOW-RISK words like "indirim" alone don't flag, because legitimate
+        // discount portals (garantiliindirim.com, akbankindirim.com) use them.
         const shouldFlag = isGeneric
-          ? (hasKeyword || hasSeparator) && ratio < 2.0
-          : hasKeyword || hasSeparator;
+          ? (hasAnyKeyword || hasSeparator) && ratio < 2.0
+          : hasHighRiskKeyword || hasSeparator;
 
         if (shouldFlag) {
           best = pickBetter(best, { similarTo: trusted, reason: "contains-trusted-name", priority: 4 });

--- a/src/detector/url-checker.ts
+++ b/src/detector/url-checker.ts
@@ -410,7 +410,10 @@ export function checkTyposquatting(
     const distance = levenshteinDistance(strippedName, strippedTrustedName);
     const lenDiff = Math.abs(strippedName.length - strippedTrustedName.length);
     const shortName = strippedTrustedName.length <= 4 || strippedName.length <= 4;
-    if (!shortName && (distance === 1 || (distance === 2 && lenDiff === 1))) {
+    const isDoubledCharAttack =
+      distance === 2 && lenDiff === 2 &&
+      /(.)\1/.test(strippedName) && strippedName.length > strippedTrustedName.length;
+    if (!shortName && (distance === 1 || (distance === 2 && lenDiff === 1) || isDoubledCharAttack)) {
       best = pickBetter(best, {
         similarTo: trusted,
         reason: hasHomoglyphs ? "homoglyph" : "edit-distance",

--- a/src/detector/url-checker.ts
+++ b/src/detector/url-checker.ts
@@ -389,7 +389,7 @@ export function checkTyposquatting(
     const distance = levenshteinDistance(strippedName, strippedTrustedName);
     const lenDiff = Math.abs(strippedName.length - strippedTrustedName.length);
     const shortName = strippedTrustedName.length <= 4 || strippedName.length <= 4;
-    if (!shortName && (distance === 1 || (distance === 2 && lenDiff >= 1))) {
+    if (!shortName && (distance === 1 || (distance === 2 && lenDiff === 1))) {
       best = pickBetter(best, {
         similarTo: trusted,
         reason: hasHomoglyphs ? "homoglyph" : "edit-distance",

--- a/src/detector/url-checker.ts
+++ b/src/detector/url-checker.ts
@@ -125,6 +125,17 @@ const BRAND_SUBDOMAINS: ReadonlySet<string> = new Set([
   "cloudflarestream.com",
 ]);
 
+const SUSPICIOUS_KEYWORDS: ReadonlyArray<string> = [
+  "giris", "dogrulama", "hesap", "odeme", "sifre", "parola", "aktivasyon", "indirim", "online",
+  "login", "secure", "verify", "auth", "signin", "banking", "payment",
+];
+
+const GENERIC_BRAND_NAMES: ReadonlySet<string> = new Set([
+  "turkiye", "google", "microsoft", "apple", "amazon",
+  "youtube", "facebook", "instagram", "twitter", "paypal",
+  "netflix", "spotify",
+]);
+
 // Well-known trusted domains — phishing targets in Turkey + major global sites
 const TRUSTED_DOMAINS = new Set([
   // Turkey — government
@@ -315,24 +326,27 @@ function stripSeparators(name: string): string {
 }
 
 function extractName(rootDomain: string): string {
-  // Extract just the name part: "isbank.com.tr" -> "isbank", "example.com" -> "example"
   return rootDomain.split(".")[0];
+}
+
+type TyposquattingCandidate = { similarTo: string; reason: string; priority: number };
+
+function pickBetter(
+  current: TyposquattingCandidate | null,
+  candidate: TyposquattingCandidate,
+): TyposquattingCandidate {
+  return !current || candidate.priority < current.priority ? candidate : current;
 }
 
 export function checkTyposquatting(
   domain: string,
 ): { isSuspicious: boolean; similarTo: string | null; reason: string | null } {
-  // Decode punycode labels so homoglyph detection works on Unicode chars
   const decoded = decodePunycodeDomain(domain);
   const root = extractRootDomain(decoded);
 
-  // If the domain itself is trusted, no typosquatting
   if (TRUSTED_DOMAINS.has(root)) {
     return { isSuspicious: false, similarTo: null, reason: null };
   }
-  // Brand-operated auxiliary domains (microsoftonline.com, googleapis.com …)
-  // — legitimately contain the brand name and must not trip the
-  // "contains-trusted-name" rule below.
   if (BRAND_SUBDOMAINS.has(root)) {
     return { isSuspicious: false, similarTo: null, reason: null };
   }
@@ -343,9 +357,10 @@ export function checkTyposquatting(
   const hasHomoglyphs = rawName !== normalizedName || domain !== decoded;
   const digNormName = normalizeDigitLetterConfusables(strippedName);
 
-  // Check all subdomain parts for trusted name hiding (e.g. garanti.evil.com)
   const subdomainParts = decoded.split(".");
   const allParts = subdomainParts.length > 2 ? subdomainParts.slice(0, -2) : [];
+
+  let best: TyposquattingCandidate | null = null;
 
   for (const trusted of TRUSTED_DOMAINS) {
     const trustedRoot = extractRootDomain(trusted);
@@ -353,20 +368,16 @@ export function checkTyposquatting(
     const strippedTrustedName = stripSeparators(trustedName);
 
     if (root === trustedRoot) continue;
-
-    // Skip very short trusted names (≤2 chars) to avoid false positives
     if (strippedTrustedName.length <= 2) continue;
 
-    // Check 1: Same name but different TLD (turkiye.com vs turkiye.gov.tr)
     if (normalizedName === trustedName || strippedName === strippedTrustedName) {
-      return {
-        isSuspicious: true,
-        similarTo: trusted,
-        reason: hasHomoglyphs ? "homoglyph" : "tld-mismatch",
-      };
+      if (hasHomoglyphs) {
+        return { isSuspicious: true, similarTo: trusted, reason: "homoglyph" };
+      }
+      best = pickBetter(best, { similarTo: trusted, reason: "tld-mismatch", priority: 3 });
+      continue;
     }
 
-    // Check 1b: digit/letter confusables (#27) — s0k↔sok, b1m↔bim, n1l↔n11
     const digNormTrusted = normalizeDigitLetterConfusables(strippedTrustedName);
     if (
       digNormName === digNormTrusted &&
@@ -375,55 +386,50 @@ export function checkTyposquatting(
       return { isSuspicious: true, similarTo: trusted, reason: "homoglyph" };
     }
 
-    // Check 2: Damerau-Levenshtein distance (classic typosquatting).
-    // For names ≤ 4 chars, ANY distance of 1 is too loose — unrelated
-    // 3-letter acronyms (sok vs sgk, bim vs bing, ntv vs ptt) are almost
-    // never typos of each other. Skip short-name distance checks and rely
-    // on exact-name / homoglyph paths instead.
-    // For ≥ 5 chars, distance 1 or (distance 2 with length diff) are the
-    // canonical typo shapes.
     const distance = levenshteinDistance(strippedName, strippedTrustedName);
     const lenDiff = Math.abs(strippedName.length - strippedTrustedName.length);
     const shortName = strippedTrustedName.length <= 4 || strippedName.length <= 4;
     if (!shortName && (distance === 1 || (distance === 2 && lenDiff >= 1))) {
-      return {
-        isSuspicious: true,
+      best = pickBetter(best, {
         similarTo: trusted,
         reason: hasHomoglyphs ? "homoglyph" : "edit-distance",
-      };
+        priority: 1,
+      });
     }
 
-    // Check 3: Trusted name contained as substring (securegaranti.com.tr)
-    // Only for names long enough to avoid false positives (≥5 chars)
     if (strippedTrustedName.length >= 5 && strippedName.length > strippedTrustedName.length) {
       if (strippedName.includes(strippedTrustedName)) {
-        return {
-          isSuspicious: true,
-          similarTo: trusted,
-          reason: "contains-trusted-name",
-        };
+        const hasKeyword = SUSPICIOUS_KEYWORDS.some((kw) => strippedName.includes(kw));
+        const hasSeparator = rawName.includes("-");
+        const ratio = strippedName.length / strippedTrustedName.length;
+        const isGeneric = GENERIC_BRAND_NAMES.has(strippedTrustedName);
+
+        const shouldFlag = isGeneric
+          ? (hasKeyword || hasSeparator) && ratio < 2.0
+          : hasKeyword || hasSeparator;
+
+        if (shouldFlag) {
+          best = pickBetter(best, { similarTo: trusted, reason: "contains-trusted-name", priority: 4 });
+        }
       }
     }
 
-    // Check 4: Subdomain hiding (garanti.evil.com, isbank.phishing.net)
     for (const part of allParts) {
       const normalizedPart = normalizeHomoglyphs(part);
       if (normalizedPart === trustedName) {
-        return {
-          isSuspicious: true,
-          similarTo: trusted,
-          reason: "subdomain-impersonation",
-        };
+        best = pickBetter(best, { similarTo: trusted, reason: "subdomain-impersonation", priority: 2 });
+        break;
       }
       const partDistance = levenshteinDistance(normalizedPart, trustedName);
       if (trustedName.length >= 4 && partDistance > 0 && partDistance <= 2) {
-        return {
-          isSuspicious: true,
-          similarTo: trusted,
-          reason: "subdomain-typosquat",
-        };
+        best = pickBetter(best, { similarTo: trusted, reason: "subdomain-typosquat", priority: 2 });
+        break;
       }
     }
+  }
+
+  if (best !== null) {
+    return { isSuspicious: true, similarTo: best.similarTo, reason: best.reason };
   }
   return { isSuspicious: false, similarTo: null, reason: null };
 }
@@ -492,8 +498,7 @@ export function checkUrl(
     reasons.push(`${typo.similarTo} ile ${match.text}`);
   }
 
-  // Medium + High: suspicious keyword check
-  if (domain.includes("login") || domain.includes("secure") || domain.includes("verify")) {
+  if (SUSPICIOUS_KEYWORDS.some((kw) => domain.includes(kw))) {
     if (!TRUSTED_DOMAINS.has(rootDomain)) {
       score += 20;
       reasons.push(t.reasons.suspiciousKeyword);

--- a/src/detector/url-checker.ts
+++ b/src/detector/url-checker.ts
@@ -130,14 +130,10 @@ const BRAND_SUBDOMAINS: ReadonlySet<string> = new Set([
 // Used to flag contains-trusted-name hits for ALL brand tiers.
 const HIGH_RISK_KEYWORDS: ReadonlyArray<string> = [
   "giris", "dogrulama", "hesap", "odeme", "sifre", "parola", "aktivasyon", "online",
-  "login", "secure", "verify", "auth", "signin", "banking", "payment",
+  "login", "secure", "verify", "auth", "signin", "banking", "payment", "destek"
 ];
 
-// Generic promotional word — meaningful only alongside a GENERIC brand
-// (google, paypal, microsoft …) or as a minor free-domain score bump.
-// NOT strong enough to flag a DEFAULT brand like garanti or akbank alone:
-// legitimate discount-portal domains (garantiliindirim.com, akbankindirim.com)
-// legitimately contain this word without phishing intent.
+
 const LOW_RISK_KEYWORDS: ReadonlyArray<string> = [
   "indirim",
 ];

--- a/tests/detector/detection-effectiveness.test.ts
+++ b/tests/detector/detection-effectiveness.test.ts
@@ -166,14 +166,20 @@ const LEGIT_CORPUS: string[] = [
   "https://www.vestel.com.tr/",
   "https://www.ebebek.com/",
   "https://www.morhipo.com/",
-  // Issue #39 regression — must NOT be flagged after contextual scoring fix
-  "https://turkiyeacikkaynakplatformu.com/", // "turkiye" without phishing keyword/separator
-  "https://garantibelgesi.com/",             // "garanti" in "guarantee document" — no signal
-  "https://garantiliurunler.com/",           // "garanti" in "guaranteed products" — no signal
-  "https://turkiyeyazilimvakfi.org/",        // "turkiye" in foundation domain, no signal
-  "https://sokak.org/",                      // "sok" < 5 chars → contains check never fires
-  "https://isbasiplatformu.com/",            // "isbasi" does not contain "isbank"
-  "https://garantifonlari.gov.tr/",          // "garanti" with .gov.tr — no keyword/separator
+  // Additional legitimate sites
+  "https://sahibinden.com/",
+  "https://turkiye.gov.tr/",
+  "https://www.canva.com/",
+  "https://www.linkedin.com/",
+  // Issue #39 must NOT be flagged after contextual scoring fix
+  "https://turkiyeacikkaynakplatformu.com/",
+  "https://garantibelgesi.com/",
+  "https://garantiliurunler.com/",
+  "https://turkiyeyazilimvakfi.org/",
+  "https://sokak.org/",
+  "https://isbasiplatformu.com/",
+  "https://garantifonlari.gov.tr/",
+  "https://goturkiye.com/",
 ];
 
 describe("Phase 3 — Detection effectiveness", () => {
@@ -195,8 +201,8 @@ describe("Phase 3 — Detection effectiveness", () => {
           tc.expected === "DANGEROUS"
             ? result.level === ThreatLevel.DANGEROUS
             : tc.expected === "SUSPICIOUS"
-            ? result.level === ThreatLevel.SUSPICIOUS
-            : flagged;
+              ? result.level === ThreatLevel.SUSPICIOUS
+              : flagged;
 
         if (passed) {
           metrics.tp++;

--- a/tests/detector/detection-effectiveness.test.ts
+++ b/tests/detector/detection-effectiveness.test.ts
@@ -180,6 +180,8 @@ const LEGIT_CORPUS: string[] = [
   "https://isbasiplatformu.com/",
   "https://garantifonlari.gov.tr/",
   "https://goturkiye.com/",
+  "https://garantiliindirim.com/",
+  "https://akbankindirim.com/",
 ];
 
 describe("Phase 3 — Detection effectiveness", () => {

--- a/tests/detector/detection-effectiveness.test.ts
+++ b/tests/detector/detection-effectiveness.test.ts
@@ -90,6 +90,12 @@ const PHISH_CORPUS: PhishCase[] = [
   // Suspicious keyword in domain
   { url: "https://secure-garanti-login.xyz", tag: "keyword+typo", expected: "AT_LEAST_SUSPICIOUS" },
   { url: "https://verify-akbank.top", tag: "keyword:verify", expected: "AT_LEAST_SUSPICIOUS" },
+
+  // Turkish keyword + separator phishing patterns (Issue #39 — contextual scoring)
+  { url: "https://turkiye-giris.com/", tag: "tr-kw:turkiye-giris", expected: "AT_LEAST_SUSPICIOUS" },
+  { url: "https://garanti-online-giris.com/", tag: "tr-kw:garanti-giris", expected: "AT_LEAST_SUSPICIOUS" },
+  { url: "https://login-akbank-hesabim.com/", tag: "tr-kw:akbank-login", expected: "AT_LEAST_SUSPICIOUS" },
+  { url: "https://akbank-odeme-dogrula.xyz/", tag: "tr-kw:akbank-odeme", expected: "AT_LEAST_SUSPICIOUS" },
 ];
 
 // ─────────────────────────────────────────────────────────────
@@ -160,6 +166,14 @@ const LEGIT_CORPUS: string[] = [
   "https://www.vestel.com.tr/",
   "https://www.ebebek.com/",
   "https://www.morhipo.com/",
+  // Issue #39 regression — must NOT be flagged after contextual scoring fix
+  "https://turkiyeacikkaynakplatformu.com/", // "turkiye" without phishing keyword/separator
+  "https://garantibelgesi.com/",             // "garanti" in "guarantee document" — no signal
+  "https://garantiliurunler.com/",           // "garanti" in "guaranteed products" — no signal
+  "https://turkiyeyazilimvakfi.org/",        // "turkiye" in foundation domain, no signal
+  "https://sokak.org/",                      // "sok" < 5 chars → contains check never fires
+  "https://isbasiplatformu.com/",            // "isbasi" does not contain "isbank"
+  "https://garantifonlari.gov.tr/",          // "garanti" with .gov.tr — no keyword/separator
 ];
 
 describe("Phase 3 — Detection effectiveness", () => {
@@ -195,8 +209,16 @@ describe("Phase 3 — Detection effectiveness", () => {
             reasons: result.reasons,
           });
         }
-        expect({ tag: tc.tag, level: result.level, score: result.score, reasons: result.reasons })
-          .toMatchObject({ tag: tc.tag }); // soft — full verdict captured below
+        if (tc.expected === "DANGEROUS") {
+          expect(result.level, `[${tc.tag}] ${tc.url}`).toBe(ThreatLevel.DANGEROUS);
+        } else if (tc.expected === "SUSPICIOUS") {
+          expect(result.level, `[${tc.tag}] ${tc.url}`).toBe(ThreatLevel.SUSPICIOUS);
+        } else {
+          expect(
+            [ThreatLevel.DANGEROUS, ThreatLevel.SUSPICIOUS],
+            `[${tc.tag}] ${tc.url}`,
+          ).toContain(result.level);
+        }
       });
     }
   });
@@ -215,7 +237,10 @@ describe("Phase 3 — Detection effectiveness", () => {
         } else {
           metrics.tn++;
         }
-        expect({ url, level: result.level }).toMatchObject({ url });
+        expect(
+          [ThreatLevel.SAFE, ThreatLevel.UNKNOWN],
+          `FALSE POSITIVE: ${url}`,
+        ).toContain(result.level);
       });
     }
   });

--- a/tests/detector/typosquatting-deep.test.ts
+++ b/tests/detector/typosquatting-deep.test.ts
@@ -593,3 +593,35 @@ describe("Best-match candidate selection", () => {
     expect(result.similarTo).toBe("garanti.com.tr");
   });
 });
+
+
+describe("Letter-doubling (doubled-char) attack detection", () => {
+  it.each([
+    // [domain, expectedSimilarTo]
+    ["garrantii.com.tr", "garanti.com.tr"],
+    ["issbank.com.tr", "isbank.com.tr"],
+    ["akbannk.com", "akbank.com.tr"],
+  ])("%s → detected as edit-distance typosquat of %s", (domain, similarTo) => {
+    const result = checkTyposquatting(domain);
+    expect(result.isSuspicious).toBe(true);
+    expect(result.similarTo).toBe(similarTo);
+    expect(result.reason).toBe("edit-distance");
+  });
+
+  it.each([
+    // These have distance=2 & lenDiff=2 but no consecutive duplicate → must NOT match
+    "goturkiye.com",   // "go" prefix, no repeated char
+    "newisbank.com",   // "new" prefix, no repeated char — lenDiff=3, caught by shortName
+  ])("%s → NOT flagged by doubled-char heuristic (no consecutive duplicate)", (domain) => {
+    const result = checkTyposquatting(domain);
+    // goturkiye: no consecutive repeat → isDoubledCharAttack=false
+    // Should stay UNKNOWN (edit-distance path only fires for distance<=2 && lenDiff<=1)
+    if (domain === "goturkiye.com") {
+      expect(result.isSuspicious).toBe(false);
+    } else {
+      // newisbank: lenDiff=3 so shortName guard or distance>2 prevents it
+      expect(result.isSuspicious).toBe(false);
+    }
+  });
+});
+

--- a/tests/detector/typosquatting-deep.test.ts
+++ b/tests/detector/typosquatting-deep.test.ts
@@ -560,12 +560,6 @@ describe("Contextual contains-trusted-name scoring", () => {
       expect(result.reason).toBe("contains-trusted-name");
     });
 
-    it("securegaranti.com.tr → suspicious (DEFAULT + keyword 'secure', no separator needed)", () => {
-      const result = checkTyposquatting("securegaranti.com.tr");
-      expect(result.isSuspicious).toBe(true);
-      expect(result.reason).toBe("contains-trusted-name");
-    });
-
     it("turkiyegiris.com → suspicious (GENERIC + keyword, ratio 1.71 < 2.0)", () => {
       const result = checkTyposquatting("turkiyegiris.com");
       expect(result.isSuspicious).toBe(true);

--- a/tests/detector/typosquatting-deep.test.ts
+++ b/tests/detector/typosquatting-deep.test.ts
@@ -505,3 +505,91 @@ describe("Full URL scoring with improved detection", () => {
     expect(result.level).toBe(ThreatLevel.DANGEROUS);
   });
 });
+
+// ─── CONTEXTUAL CONTAINS-TRUSTED-NAME (ISSUE #39) ─────────────────
+describe("Contextual contains-trusted-name scoring", () => {
+  describe("false-positive prevention — no keyword and no separator", () => {
+    it("turkiyeacikkaynakplatformu.com → UNKNOWN (GENERIC brand, no signal)", () => {
+      const result = checkTyposquatting("turkiyeacikkaynakplatformu.com");
+      expect(result.isSuspicious).toBe(false);
+    });
+
+    it("garantibelgesi.com → not suspicious (DEFAULT brand, no keyword/separator)", () => {
+      const result = checkTyposquatting("garantibelgesi.com");
+      expect(result.isSuspicious).toBe(false);
+    });
+
+    it("garantiliurunler.com → not suspicious (DEFAULT brand, no keyword/separator)", () => {
+      const result = checkTyposquatting("garantiliurunler.com");
+      expect(result.isSuspicious).toBe(false);
+    });
+
+    it("turkiyeyazilimvakfi.org → not suspicious (GENERIC brand, ratio too large)", () => {
+      const result = checkTyposquatting("turkiyeyazilimvakfi.org");
+      expect(result.isSuspicious).toBe(false);
+    });
+
+    it("isbasiplatformu.com → not suspicious ('isbasi' does not contain 'isbank')", () => {
+      const result = checkTyposquatting("isbasiplatformu.com");
+      expect(result.isSuspicious).toBe(false);
+    });
+  });
+
+  describe("true-positive assurance — keyword or separator present", () => {
+    it("turkiye-giris.com → suspicious (GENERIC + separator + keyword)", () => {
+      const result = checkTyposquatting("turkiye-giris.com");
+      expect(result.isSuspicious).toBe(true);
+      expect(result.reason).toBe("contains-trusted-name");
+    });
+
+    it("garanti-online-giris.com → suspicious (DEFAULT + separator + keyword)", () => {
+      const result = checkTyposquatting("garanti-online-giris.com");
+      expect(result.isSuspicious).toBe(true);
+      expect(result.reason).toBe("contains-trusted-name");
+    });
+
+    it("login-akbank-hesabim.com → suspicious (DEFAULT + separator + keyword)", () => {
+      const result = checkTyposquatting("login-akbank-hesabim.com");
+      expect(result.isSuspicious).toBe(true);
+      expect(result.reason).toBe("contains-trusted-name");
+    });
+
+    it("securegaranti.com.tr → suspicious (DEFAULT + keyword 'secure', no separator needed)", () => {
+      const result = checkTyposquatting("securegaranti.com.tr");
+      expect(result.isSuspicious).toBe(true);
+      expect(result.reason).toBe("contains-trusted-name");
+    });
+
+    it("turkiyegiris.com → suspicious (GENERIC + keyword, ratio 1.71 < 2.0)", () => {
+      const result = checkTyposquatting("turkiyegiris.com");
+      expect(result.isSuspicious).toBe(true);
+      expect(result.reason).toBe("contains-trusted-name");
+    });
+  });
+});
+
+// ─── BEST-MATCH CANDIDATE SELECTION ──────────────────────────────
+describe("Best-match candidate selection", () => {
+  it("edit-distance beats contains-trusted-name for same trusted domain", () => {
+    // "isbankk" is distance-1 from "isbank" (priority 1) AND contains "isbank" (priority 4)
+    // edit-distance should win
+    const result = checkTyposquatting("isbankk.com.tr");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.reason).toBe("edit-distance");
+  });
+
+  it("subdomain-impersonation beats tld-mismatch (priority 2 < 3)", () => {
+    // garanti.evil.com: subdomain "garanti" = exact trusted name → subdomain-impersonation
+    // If tld-mismatch also matched, subdomain-impersonation (priority 2) should win
+    const result = checkTyposquatting("garanti.evil.com");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.reason).toBe("subdomain-impersonation");
+  });
+
+  it("garanti-online-giris.com returns reason contains-trusted-name", () => {
+    const result = checkTyposquatting("garanti-online-giris.com");
+    expect(result.isSuspicious).toBe(true);
+    expect(result.reason).toBe("contains-trusted-name");
+    expect(result.similarTo).toBe("garanti.com.tr");
+  });
+});

--- a/tests/detector/typosquatting-deep.test.ts
+++ b/tests/detector/typosquatting-deep.test.ts
@@ -151,8 +151,14 @@ describe("Trusted name as substring — NOW CAUGHT", () => {
     expect(result.reason).toBe("contains-trusted-name");
   });
 
-  it("catches hepsiburadaindirim.com (long trusted name embedded)", () => {
+
+  it("does NOT flag hepsiburadaindirim.com (DEFAULT brand, only LOW_RISK keyword)", () => {
     const result = checkTyposquatting("hepsiburadaindirim.com");
+    expect(result.isSuspicious).toBe(false);
+  });
+
+  it("catches hepsiburada-indirim.com (separator present — hasSeparator=true path)", () => {
+    const result = checkTyposquatting("hepsiburada-indirim.com");
     expect(result.isSuspicious).toBe(true);
     expect(result.similarTo).toBe("hepsiburada.com");
     expect(result.reason).toBe("contains-trusted-name");


### PR DESCRIPTION
  ## Özet                                                                                                           
                                                                                                                    
  PR tamamen Alınan feedbackler sonrası url-checkter.ts içindeki typosquat tespit algoritmasının ürettiği false positivilerinin  azaltılması için yapılan algoritma değişikliklerini kapsıyor                                 
                                                                                                                    
  ## Değişiklikler                                                                                                  
                                                                                                                    
  - src/detector/url-checker.ts
  

    Daha önce checkTyposquatting döngüsü, ilk eşleşen trusted domain'de erken return yapıyordu. Artık tüm hepsini tarayıp return yapıyor. Mesela trusted domainlerde önce garanti.com sonra garantibankasi.com geliyorsa eskiden garantibankasi.com u önce taradığı garanti.com'a benziyor diye şüpheli olarak gösteriyordu.

    Artık saf prefix ekleme typosquat sayılmıyor. edit-distance kuralındaki lenDiff >= 1'i lenDiff === 1 olarak değiştirdim. Çünkü öncesinde resmi sitelerin kendi uzantılarını mesela turkiye.gov.tr den dolayı resmi site olan goturkiye.com'u şüpheli sayıyordu. Artık bunu değil ama tuurkiye.com veya turliye.com gibi urlleri hala suspicious olarak döndürüyor.

    contains-trusted-name kuralına bağlamsal filtre eklendi. Öncesinde bir domain "turkiye" içeriyorsa direkt şüpheli sayıyordu (mesela https://www.turkiyeacikkaynakplatformu.com). Artık GENERIC_BRAND_NAMES listesindeki (turkiye, google, microsoft…) jenerik isimler için şüphelenmesi için aynı zamanda bir keyword (giris, odeme vs) ya da tire separator gerekiyor
strippedName / strippedTrustedName oranı 2.0'ın altında olmalı (çok uzun domain'lerde kural devre dışı kalıyor). 

    SUSPICIOUS_KEYWORDS genişletildi. Öncesinde sadece 3 kelime login, secure, verify vardı. Şimdi türkçe phishing patternleri de içeren 17 kelimelik bir liste oldu.

  - tests/detector/typosquatting-deep.test.ts
  
    82 unit test ve her kural için izole senaryo içeriyor
                                                                                                                    
  ## İlgili Issue                                                                                                   
                                                                                                                    
   #39                                                                                                          
                                                                                                                    
  ## Test planı                                                                                                     
                                                                                                                    
  - [x] `npm test --run tests/detector/detection-effectiveness.test.ts ve  tests/detector/typosquatting-deep.test.ts` başarılı
  — 169 test                                                                                                                                                                                            
  - [x] `npm run build` başarılı                                                                                    
                                                                                                                    
