### PR TITLE
chore: Claude Code dev setup + bump to v0.4.0

### DIFF
--- a/.claude/agents/detection-reviewer.md
+++ b/.claude/agents/detection-reviewer.md
@@ -1,0 +1,51 @@
+---
+name: detection-reviewer
+description: Reviews changes to Alparslan's detection / allowlist / blocking / messaging code against the documented security invariants and detection correctness. Read-only — reports findings, never edits. Use before merging any change under src/detector, src/blocklist, src/network, src/background, or src/utils/{safe-fetch,whitelist-normalize}.
+tools: Read, Grep, Glob, Bash
+---
+
+# Detection Reviewer
+
+You are a security-focused reviewer for **Alparslan**, a Manifest V3
+anti-phishing browser extension. You audit changes that could weaken user
+protection. You are **read-only**: produce findings, never modify code.
+
+## Inputs
+
+A diff/PR/branch to review. If not given a range, use `git diff main...HEAD`.
+
+## What to check
+
+Read `.claude/rules/security-invariants.md` and `.claude/rules/architecture.md`
+first, then evaluate the change on two axes:
+
+### 1. Security invariants (must not regress)
+- **Sender verification** — new mutating message types must join the privileged
+  set guarded by `isFromExtensionPage` in `src/background/index.ts`.
+- **Allowlist guards** — public-suffix and single-label rejection in
+  `utils/whitelist-normalize.ts` and `blocklist/whitelist-updater.ts`; the
+  >50%-shrink rejection.
+- **USOM integrity** — `verifyIntegrity()` stays on the update path; no list
+  applied without a hash check.
+- **URL sanitization** — no full URL (query/fragment) persisted without
+  `sanitizeUrlForStorage()`.
+- **Bounded fetches** — every remote fetch goes through `utils/safe-fetch.ts` caps.
+- **Rate limiting** — abuse-prone user-triggered messages stay capped.
+- **Logging PII** — no URLs / `sender.url` logged outside debug mode.
+
+### 2. Detection correctness
+- Could the change cause **false negatives** (a real threat no longer flagged) or
+  **false positives** (a legit site now flagged)? Reason about the
+  allowlist short-circuit and the `checkTyposquatting` order.
+- Is `TRUSTED_DOMAINS` / brand-subdomain handling still consistent?
+- Is there a **test** locking each changed behavior? Check `tests/detector/*`
+  and the E2E FP-regression cases in
+  `e2e/specs/phase3-detection-ux.spec.ts`. Run `npm test` if useful.
+
+## Output
+
+A concise report:
+- **Verdict:** APPROVE / REQUEST CHANGES.
+- **Findings:** each as `severity (high/med/low) — file:area — what & why — suggested fix + test`.
+- Lead with anything that regresses an invariant or detection. If clean, say so
+  plainly and note which invariants you confirmed.

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,0 +1,17 @@
+---
+description: Build and package all three browser targets, then verify versions match
+---
+
+Build and package the extension for all targets, then verify the artifacts.
+
+1. Run the three builds (each runs `tsc --noEmit` first):
+   - `npm run build` → `dist/` (Chrome MV3)
+   - `npm run build:firefox` → `dist-firefox/` (Firefox MV2)
+   - `npm run build:safari` → `dist-safari/` (Safari MV3)
+2. Package each: `npm run package`, `npm run package:firefox`, `npm run package:safari`.
+3. Verify the version in `package.json` matches `"version"` in the built
+   `dist/manifest.json`, `dist-firefox/manifest.json`, and `dist-safari/manifest.json`.
+   Report any mismatch — all four must agree.
+4. Confirm each `.zip` is non-empty and lists `manifest.json` at its root.
+
+Report a concise pass/fail summary with the resolved version and any errors.

--- a/.claude/commands/release-prep.md
+++ b/.claude/commands/release-prep.md
@@ -1,0 +1,28 @@
+---
+description: Bump the version across all four files in lockstep, then verify
+argument-hint: <new-version, e.g. 0.5.0>
+---
+
+Prepare a release by bumping the version to **$ARGUMENTS** (semver, no leading `v`).
+
+The version lives in **four** files that must always agree:
+
+- `package.json`
+- `manifest.json` (Chrome MV3)
+- `manifest.firefox.json` (Firefox MV2)
+- `manifest.safari.json` (Safari MV3)
+
+Steps:
+
+1. Read the current version from `package.json`. Confirm `$ARGUMENTS` is a valid
+   forward bump (greater than current). If no argument was given, ask for the
+   target version — do not guess.
+2. Update the `"version"` field in all four files to `$ARGUMENTS`.
+3. `npm test` and `npm run build` (chrome) to confirm a clean build + green tests.
+4. Verify the built `dist/manifest.json` shows `$ARGUMENTS`.
+5. Show the diff and stop. **Do not commit, tag, push, or publish** — the human
+   confirms, then commits as `chore(release): bump version <old> → $ARGUMENTS`.
+
+After merge, the release is cut by publishing a GitHub Release tagged
+`v$ARGUMENTS`, which triggers `.github/workflows/release.yml` to build and attach
+the store zips. Store upload remains manual (see CLAUDE.md → Release process).

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,18 @@
+---
+description: Run the unit suite (and optionally the E2E suite), then summarize
+---
+
+Run the project's tests and report results.
+
+1. **Unit (always):** `npm test` (vitest). Report files/tests passed and any
+   failures with the failing test names.
+2. **Lint:** `npm run lint`. Report violations.
+3. **E2E (only if the user asks, or when changing detection/UI/messaging):**
+   `npm run test:e2e`. This builds and loads the extension via the Playwright
+   fixture; it is slower and launches a browser. Use `npm run test:e2e:headed`
+   when debugging.
+
+When a detection rule, security invariant (see CLAUDE.md), or message handler
+changed, a matching unit test must exist or be added — call out any gap.
+
+Summarize: unit pass/fail counts, lint status, and (if run) E2E results.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,79 @@
+# Architecture
+
+Alparslan is a cross-browser **Manifest V3** anti-phishing extension
+(TypeScript + React 18 + Vite 5), focused on threats targeting Turkey. All
+detection is **client-side** — browsing data never leaves the device. Ships for
+Chrome/Chromium (MV3), Firefox (MV2), and Safari (MV3).
+
+## Module map
+
+```
+src/
+├── background/   Service worker (MV3) / background script (MV2). Message hub + orchestration.
+│                 Verifies privileged-message senders; gates CHECK_URL on list readiness.
+├── content/      Injected page script: Shadow-DOM warning banner, SPA URL tracking, page analysis.
+├── popup/        React popup (status badge, history, URL check, whitelist UI, dashboard).
+├── options/      React options/settings page.
+├── detector/     Detection engine:
+│                   url-checker.ts    URL heuristics: homoglyph + digit-letter confusables,
+│                                     typosquatting, Damerau-Levenshtein, subdomain hiding,
+│                                     IP / risky-TLD checks, punycode decode. TRUSTED_DOMAINS set.
+│                   page-analyzer.ts  Page-content heuristics: login/CC forms, external form
+│                                     actions, TC Kimlik patterns, urgency language.
+├── blocklist/    Threat data:
+│                   bloom-filter.ts      FNV-1a Bloom filter (fast USOM membership test).
+│                   indexeddb-store.ts   USOM domains in IndexedDB (confirmation lookups).
+│                   updater.ts           Remote blocklist fetch + scheduling (chrome.alarms).
+│                   usom-updater.ts      Turkish CERT (USOM) list: fetch, integrity-verify, Bloom.
+│                   whitelist-updater.ts Dynamic allowlist + UGC domains + risky TLDs.
+├── network/      Request layer:
+│                   dnr-manager.ts       declarativeNetRequest block rules (Chrome/Safari MV3).
+│                   request-monitor.ts   webRequest monitoring + per-tab stats (Firefox path).
+│                   url-check-cache.ts   In-memory TTL cache of heuristic results.
+├── storage/      idb.ts (IndexedDB), list-cache.ts (in-memory whitelist/blacklist Sets w/ parent-domain match).
+├── breach/       Local breach-DB lookup.
+├── dashboard/    Metrics + risk-score for the popup dashboard.
+├── privacy/      Tracker-blocking rules.
+└── utils/        browser-polyfill, safe-fetch (size/timeout caps), whitelist-normalize, logger, types.
+```
+
+## Detection data flow (navigate → block/warn)
+
+1. `chrome.tabs.onUpdated` (main_frame complete) → `background/index.ts`.
+2. **Allowlist short-circuit:** `isWhitelisted(host)` (exact + up to 3 parent
+   domains) → SAFE immediately, no further checks.
+3. `checkUrlConfirmed(url, protectionLevel)`:
+   - **Blacklist** (`isBlacklisted`) and **USOM Bloom** (`usomBloomTest`) →
+     DANGEROUS (early return). A USOM hit is **confirmed** against IndexedDB to
+     drop Bloom false positives.
+   - **Dynamic whitelist** → SAFE (early return).
+   - `low` protection → blocklist only; `medium`/`high` add heuristics
+     (`high` lowers the DANGEROUS/SUSPICIOUS thresholds).
+   - `checkTyposquatting` → punycode decode → homoglyph + digit-letter
+     normalization → exact / edit-distance / substring / subdomain-hiding checks
+     against `TRUSTED_DOMAINS`.
+4. Badge updated (✓ / ! / ?), and on DANGEROUS/SUSPICIOUS with DOM warnings
+   enabled, `SHOW_WARNING` → content script renders a Shadow-DOM banner.
+
+## Build system (vite.config.ts)
+
+One config, multiple `--mode`s. Each produces a platform output dir; a build
+plugin copies the matching manifest (`manifest.json` / `.firefox.json` /
+`.safari.json`), `lists/`, `_locales/`, `icons/`, and the hand-written
+`list.html/js` + `whitelist.html/js` pages.
+
+| Output | Modes |
+|--------|-------|
+| `dist/` (Chrome MV3) | default + `content` |
+| `dist-firefox/` (Firefox MV2) | `firefox` + `firefox-bg` + `firefox-content` |
+| `dist-safari/` (Safari MV3) | `safari` + `safari-content` |
+
+Root-level `background.js` / `content.js` / `popup.js` / `options.js` / `chunks/`
+are **build output** and are git-ignored — never commit them; they live in `dist/`.
+
+## Gotchas
+
+- USOM/whitelist data loads asynchronously; the worker gates `CHECK_URL` on
+  readiness. When testing detection, wait for it (E2E uses `__alparslanE2E`).
+- Firefox (MV2) blocks via `webRequest`, not DNR; the DNR manager no-ops there.
+- Short trusted names (≤4 chars) skip edit-distance checks by design (FP control).

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,41 @@
+# Code Style
+
+## Language & tooling
+
+- **TypeScript** throughout. **React 18** for popup/options UI. **Vite 5** build.
+- **ESLint + Prettier** are configured and enforced. Run before committing:
+  ```bash
+  npm run lint      # eslint src/
+  npm run format    # prettier --write src/
+  ```
+
+## Prettier
+
+`semi: true`, **double quotes** (`singleQuote: false`), 2-space indent,
+`trailingComma: all`, `printWidth: 100`.
+
+## ESLint
+
+Extends `eslint:recommended`, `@typescript-eslint/recommended`, `prettier`.
+- `no-unused-vars`: error, but names prefixed with `_` are ignored.
+- `no-console`: warn — `console.log` / `console.error` are allowed; avoid others.
+- Env: `browser`, `es2020`, `webextensions`.
+
+## Conventions
+
+- **English** for all code, identifiers, comments, and docs.
+- **Turkish** for user-facing strings — add them to `_locales/tr/messages.json`
+  (manifest `__MSG_*` keys) and `src/i18n/tr.ts`, never hardcode UI text.
+- Booleans read as predicates: `is*` / `has*` / `can*`.
+- Keep modules single-purpose; the existing `src/` layout (one concern per dir)
+  is the pattern to follow.
+- Prefer pure, testable functions in `detector/` and `utils/` — they carry the
+  densest unit coverage and the security-sensitive logic.
+
+## Commits & branches
+
+- [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`,
+  `docs:`, `refactor:`, `test:`, `chore:`. Reference PRs/issues (`#31`, `Closes #123`).
+- Branch prefixes: `feat/`, `fix/`, `docs/`, `refactor/`, `test/` (`chore/` for
+  tooling, `release/vX.Y.Z` for release prep).
+- Do not add `Co-Authored-By` / tool-attribution trailers to commits.

--- a/.claude/rules/principles.md
+++ b/.claude/rules/principles.md
@@ -1,0 +1,40 @@
+# Principles
+
+How agents (and contributors) should reason and work in this repository. These
+apply to every task unless a more specific rule overrides them.
+
+## 1. Think before coding
+
+- State assumptions explicitly; if uncertain, stop and ask.
+- If multiple interpretations exist, surface them — don't pick silently.
+- If a simpler approach exists, say so.
+
+## 2. Simplicity first (YAGNI)
+
+- The minimum code that solves the problem. Nothing speculative.
+- No abstractions for single-use code, no config that wasn't requested.
+
+## 3. Surgical changes
+
+- Touch only what the task requires. Match the existing style even if you'd do
+  it differently. Don't refactor working code that's unrelated to the task.
+- Remove only the imports/variables your own change orphaned.
+
+## 4. Goal-driven, verified
+
+- Turn tasks into verifiable goals: "add detection for X" → "write a failing
+  test for X, then make it pass". Run `npm test` before claiming done.
+- Never claim something works without evidence (test run / build / observed
+  behavior). If tests weren't run, say so.
+
+## 5. This is security software — be conservative
+
+- A change to detection, allowlist, blocking, or messaging can weaken user
+  protection. When in doubt, prefer the safer default and add a test.
+- Never regress a documented security invariant (see [security-invariants.md](security-invariants.md)).
+
+## 6. Communication
+
+- Code, identifiers, comments, and docs are written in **English**.
+- User-facing UI strings are **Turkish** (`_locales/tr/`, `src/i18n/tr.ts`).
+- Respond to the user in their language; keep it concise and explicit.

--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -1,0 +1,31 @@
+# Release
+
+## Version lives in four files — keep them in lockstep
+
+- `package.json`
+- `manifest.json` (Chrome MV3)
+- `manifest.firefox.json` (Firefox MV2)
+- `manifest.safari.json` (Safari MV3)
+
+All four must always show the same version. The `/release-prep` command and the
+[release skill below] automate the bump and verification.
+
+## Steps
+
+1. **Bump** all four files; commit `chore(release): bump version <old> → <new>`.
+   Verify the built `dist/manifest.json` shows the new version.
+2. **Merge** to `main`, then **publish a GitHub Release** tagged `vX.Y.Z`.
+   - The release (event: `published`) triggers `.github/workflows/release.yml`,
+     which runs tests, builds all three targets, and attaches
+     `alparslan-{chrome,firefox,safari}-vX.Y.Z.zip` to the release.
+3. **Store submission is manual** — no automation, no credentials in the repo:
+   - **Chrome Web Store** → upload the chrome zip.
+   - **Firefox AMO** → upload the firefox zip.
+   - **Safari** → `xcrun safari-web-extension-converter dist-safari/ …`, then
+     build in Xcode (see `README.md`).
+
+## Don't
+
+- Don't bump only some of the four files.
+- Don't commit build output (`dist*/`, root `*.js`, `*.zip`) — it's git-ignored.
+- Don't expect the GitHub Release to publish to the stores; that step is human.

--- a/.claude/rules/security-invariants.md
+++ b/.claude/rules/security-invariants.md
@@ -1,0 +1,51 @@
+# Security Invariants — DO NOT REGRESS
+
+These protections were added/hardened deliberately. Any change to detection,
+allowlist/blocklist, messaging, or remote-fetch code must preserve them. When you
+touch one of these areas, add or update a test that locks the behavior in.
+
+Use the [verify-security-invariants](../skills/verify-security-invariants/SKILL.md)
+skill to audit a diff against this list.
+
+## 1. Privileged-message sender verification
+`background/index.ts` → `isFromExtensionPage(sender)`. The mutating messages
+`SET_ENABLED`, `SETTINGS_UPDATED`, `ADD_TO_WHITELIST`, `REMOVE_FROM_WHITELIST`,
+`CLEAR_HISTORY` are rejected unless they originate from an extension page (same
+`runtime.id`, extension-origin URL). Content scripts must never be able to invoke
+them. New mutating message types must be added to the privileged set.
+
+## 2. Allowlist guards
+- User input goes through `utils/whitelist-normalize.ts`: strip
+  protocol/path/query/fragment/port; reject single-label entries and public
+  suffixes (`com`, `com.tr`, `gov.tr`, …).
+- The dynamic-whitelist parser (`whitelist-updater.ts`) independently rejects
+  public suffixes, so a poisoned upstream list can't whitelist an entire TLD and
+  bypass parent-domain matching.
+- Reject a refreshed list that shrank by more than ~50% (corruption / attack).
+
+## 3. USOM list integrity
+`usom-updater.ts` → `verifyIntegrity()`: strict match against an upstream-published
+SHA-256 when present; compare against the locally-stored hash for the same version
+tag to detect mid-flight tampering; on mismatch, abort the update and keep the
+previous list.
+
+## 4. URL sanitization before storage
+`sanitizeUrlForStorage()` drops query + fragment before anything is persisted
+(history, reports). Never store full URLs — they leak tokens, OAuth codes, and
+magic-link credentials.
+
+## 5. Bounded remote fetches
+`utils/safe-fetch.ts` enforces per-source size and timeout caps on every remote
+list fetch. New remote sources must go through it with an explicit cap.
+
+## 6. Rate limiting
+`REPORT_SITE` is capped (10/hour). Keep abuse-prone, user-triggered messages
+rate-limited.
+
+## 7. Logging PII contract
+Log message *types*, not URLs or `sender.url`, outside debug mode.
+
+---
+
+**Vulnerability disclosure:** email **guvenlik@dijitalsavunma.org** — never open a
+public issue for a security bug (see `CONTRIBUTING.md`).

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,51 @@
+# Testing
+
+Two layers. A detection-logic or security-invariant change without a matching
+test is incomplete.
+
+## Unit (Vitest) — `tests/`
+
+Mirrors `src/`. Run:
+```bash
+npm test            # vitest run
+npm run test:watch  # watch mode
+```
+
+Densest coverage lives in `tests/detector/` (`url-checker.test.ts`,
+`typosquatting-deep.test.ts`, `detection-effectiveness.test.ts`,
+`page-analyzer.test.ts`), plus `storage/`, `network/`, `blocklist/`,
+`background/` (message handlers + privilege checks), and
+`utils/whitelist-normalize.test.ts`.
+
+When adding a detection case, follow the existing table-driven style in
+`typosquatting-deep.test.ts`. See the
+[write-detector-test](../skills/write-detector-test/SKILL.md) skill.
+
+> Note: the suite currently emits a few non-fatal "unhandled errors" from a
+> transitive test-env dependency (`html-encoding-sniffer` → `@exodus/bytes`
+> ESM/CJS). They fail no tests and are unrelated to app code.
+
+## E2E (Playwright) — `e2e/specs/`
+
+```bash
+npm run test:e2e          # headless:false fixture; runs against the built dist/
+npm run test:e2e:headed   # visible browser
+npm run test:e2e:debug
+```
+
+The fixture (`e2e/fixtures/extension.ts`):
+- loads the **built** extension from `dist/` (run a build first if stale),
+- **stubs the GitHub list fetches** (`**/AsabiAlgo/blocklists/**`) so tests are
+  deterministic and offline,
+- waits on the `__alparslanE2E` readiness flags (`swInitDone`, `blocklistLoaded`,
+  `breachLoaded`) before the test body runs.
+
+Detection assertions go through the real background pipeline via
+`chrome.runtime.sendMessage({ type: "CHECK_URL", url })`. Keep the
+false-positive regression guards green (e.g. `ntv.com.tr`,
+`login.microsoftonline.com` must NOT be flagged).
+
+## Before opening a PR
+
+`npm test`, `npm run lint`, and a clean `npm run build` (which type-checks).
+Run `npm run test:e2e` when you changed detection, messaging, or UI.

--- a/.claude/skills/add-trusted-domain/SKILL.md
+++ b/.claude/skills/add-trusted-domain/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: add-trusted-domain
+description: Add a legitimate brand/domain to the detector's trusted set so typosquats, homoglyphs, and subdomain-hiding variants of it get flagged — with a regression test. Use when onboarding a new bank, gov service, retailer, or popular site that phishers impersonate.
+model: inherit
+---
+
+# Add a Trusted Domain
+
+Adding a brand to `TRUSTED_DOMAINS` is what makes its look-alikes (typosquats,
+homoglyphs, digit-confusables, subdomain hiding) detectable. Do this carefully —
+a wrong entry causes false positives on real sites.
+
+## Steps
+
+1. **Locate the sets** in `src/detector/url-checker.ts`:
+   - `TRUSTED_DOMAINS` — the brands to protect (root domains, e.g. `garanti.com.tr`).
+   - the brand-subdomains / legitimate-auxiliary set (e.g. `googleapis.com`,
+     `microsoftonline.com`) — used to avoid flagging legit auxiliary domains.
+
+2. **Add the domain** to `TRUSTED_DOMAINS` using its real root domain. For Turkish
+   brands this is usually `name.com.tr`. Keep the list alphabetically grouped as
+   the surrounding entries are.
+
+3. **Watch the short-name rule:** names ≤4 chars skip edit-distance checks (FP
+   control). If the brand name is short (e.g. `n11`, `bim`), confirm the
+   digit-letter confusable path (`normalizeDigitLetterConfusables`) covers the
+   realistic attack (e.g. `b1m`→`bim`) — add the case to the test below.
+
+4. **Avoid false positives:** if the new brand's name is a common word or close to
+   an existing trusted name, check it won't now flag legitimate sites. Add a
+   "NOT flagged" regression case for any nearby legit domain.
+
+5. **Add a regression test** (see the `write-detector-test` skill) in
+   `tests/detector/typosquatting-deep.test.ts` (or `url-checker.test.ts`):
+   - a look-alike of the new brand → expected SUSPICIOUS/DANGEROUS,
+   - the real brand domain → expected SAFE,
+   - any risky nearby legit domain → expected NOT flagged.
+
+6. **Verify:** `npm test`. If you changed detection broadly, also
+   `npm run build && npm run test:e2e` and confirm the FP-regression specs in
+   `e2e/specs/phase3-detection-ux.spec.ts` stay green.
+
+## Done when
+
+`npm test` is green, the new look-alike is flagged, and no real site regressed.

--- a/.claude/skills/verify-security-invariants/SKILL.md
+++ b/.claude/skills/verify-security-invariants/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: verify-security-invariants
+description: Audit a code change (a diff, a PR, or staged work) against Alparslan's documented security invariants before merge. Use when reviewing or finishing changes that touch detection, allowlist/blocklist, background messaging, storage, or remote fetches.
+model: inherit
+---
+
+# Verify Security Invariants
+
+Check that a change does not weaken any protection in
+`.claude/rules/security-invariants.md`. Read-only analysis — report findings, fix
+only if asked.
+
+## Steps
+
+1. **Get the diff:** `git diff main...HEAD` (or the staged diff). Note which
+   areas it touches: `background/`, `detector/`, `blocklist/`, `network/`,
+   `storage/`, `utils/safe-fetch.ts`, `utils/whitelist-normalize.ts`.
+
+2. **Run the checklist** against the changed code:
+   - **Sender verification** — did a new mutating message type get added without
+     being included in the privileged set guarded by `isFromExtensionPage`?
+   - **Allowlist guards** — does new allowlist handling still reject public
+     suffixes and single-label entries, and keep the >50%-shrink rejection?
+   - **USOM integrity** — is `verifyIntegrity()` still on the update path; can a
+     fetched list be applied without a hash check?
+   - **URL sanitization** — is any full URL (with query/fragment) now persisted to
+     storage/history/reports without `sanitizeUrlForStorage()`?
+   - **Bounded fetches** — does any new remote fetch bypass `utils/safe-fetch.ts`
+     size/timeout caps?
+   - **Rate limiting** — is a new user-triggered, abuse-prone message uncapped?
+   - **Logging PII** — does new logging emit URLs / `sender.url` outside debug?
+
+3. **Check test coverage** — for each weakened-or-changed invariant, is there a
+   test locking the intended behavior? Flag missing ones.
+
+4. **Report**: per invariant → `OK` / `AT RISK` (with file + reason) / `N/A`.
+   Lead with anything AT RISK. Recommend the smallest fix + the test to add.
+
+## Done when
+
+Every invariant is `OK` or `N/A`, or the AT-RISK items are clearly reported with
+a recommended fix and test.

--- a/.claude/skills/write-detector-test/SKILL.md
+++ b/.claude/skills/write-detector-test/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: write-detector-test
+description: Add a unit test for the URL/page detection engine following the project's existing table-driven style. Use when adding or changing a detection heuristic (homoglyph, typosquat, subdomain hiding, IP/TLD, page-content) or fixing a false positive/negative.
+model: inherit
+---
+
+# Write a Detector Test
+
+Detection changes must come with a test that locks the behavior. Match the
+existing patterns — don't invent a new structure.
+
+## Where tests go
+
+| Area | File |
+|------|------|
+| Core URL checks, domain extraction, edit distance | `tests/detector/url-checker.test.ts` |
+| Typosquatting (transposition, same-name/diff-TLD, subdomain hiding, substring, homoglyph, digit-confusable) | `tests/detector/typosquatting-deep.test.ts` |
+| Broad phishing-effectiveness corpus / regressions | `tests/detector/detection-effectiveness.test.ts` |
+| Page-content heuristics (forms, TCKN, urgency) | `tests/detector/page-analyzer.test.ts` |
+
+## Steps
+
+1. **Read the target test file** and copy its table-driven style (an array of
+   `[input, expectation]` cases iterated with `it.each` / a loop). Keep imports
+   and helpers consistent with what's already there.
+
+2. **Cover both directions** for any detection change:
+   - a malicious/look-alike input → expected level (SUSPICIOUS/DANGEROUS) and,
+     where asserted, the `similarTo` brand and reason,
+   - a legitimate input that's *near* the rule → expected SAFE / NOT flagged
+     (this is the false-positive guard, and it's the part people forget).
+
+3. **For a fixed false positive**, add the exact domain that misfired as a
+   permanent "must stay SAFE" case (mirror the FP-regression entries).
+
+4. **Pick the right entry point:** test the pure function
+   (`checkTyposquatting`, `checkUrl`, `analyzePage`, `normalizeWhitelistInput`,
+   …) directly — these are designed to be called without browser APIs.
+
+5. **Run:** `npm test`. Confirm your new case fails before the fix and passes
+   after (write the test first when fixing a bug).
+
+## Done when
+
+The new case(s) pass, the FP guard passes, and the rest of the suite is green.

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@ Alparslan/
 .DS_Store
 .env
 .env.local
-CLAUDE.md
-.claude/
+# Claude Code: shared team config (CLAUDE.md, .claude/settings.json, .claude/commands/)
+# is tracked; only per-developer local overrides are ignored.
+.claude/settings.local.json
 .planning/
 playwright-report
 test-results

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,184 +1,54 @@
 # CLAUDE.md — Alparslan
 
-Guidance for Claude Code (and any AI agent) working in this repository. Human
-contributors should read `CONTRIBUTING.md`; this file is the machine-facing
-companion that captures the architecture, conventions, and security invariants
-that must not be regressed.
+Guidance for Claude Code (and any AI agent) working in this repo. Humans should
+read `CONTRIBUTING.md`; this is the machine-facing companion. The detailed,
+modular rules live under `.claude/rules/` and are imported below.
 
 ## What this is
 
-**Alparslan** is a cross-browser **Manifest V3** extension that protects users
-from phishing and scam websites, with a focus on threats targeting Turkey. All
-detection runs **client-side** — browsing data never leaves the device. Ships
-for Chrome/Chromium (MV3), Firefox (MV2), and Safari (MV3).
+**Alparslan** — a cross-browser **Manifest V3** anti-phishing extension
+(TypeScript + React 18 + Vite 5), focused on threats targeting Turkey. All
+detection runs **client-side**. Ships for Chrome (MV3), Firefox (MV2), Safari (MV3).
 
-- **Language:** TypeScript. **UI:** React 18. **Build:** Vite 5.
-- **Tests:** Vitest (unit) + Playwright (E2E).
-- **Lint/format:** ESLint + Prettier.
-
-> Code, identifiers, comments, and docs are written in **English**.
-> User-facing UI strings are **Turkish** (see `_locales/tr/` and `src/i18n/tr.ts`).
+> Code/identifiers/comments/docs: **English**. User-facing UI strings: **Turkish**.
 
 ## Commands
 
 ```bash
-npm install              # install deps (use `npm ci` for a clean, lockfile-exact install)
-npm run dev              # vite build --watch (development)
-
-npm test                 # vitest run (unit)
-npm run test:watch       # vitest watch
+npm install              # deps (npm ci for a clean, lockfile-exact install)
+npm run dev              # vite build --watch
+npm test                 # vitest (unit)
 npm run lint             # eslint src/
 npm run format           # prettier --write src/
-
-npm run build            # Chrome build  -> dist/
-npm run build:firefox    # Firefox build -> dist-firefox/
-npm run build:safari     # Safari build  -> dist-safari/
-
-npm run package          # build + zip   -> dist.zip
-npm run package:firefox  # build + zip   -> dist-firefox.zip
-npm run package:safari   # build + zip   -> dist-safari.zip
-
-npm run test:e2e         # playwright (loads the built extension via a fixture)
-npm run test:e2e:headed  # with a visible browser
+npm run build            # Chrome  -> dist/        (runs tsc --noEmit first)
+npm run build:firefox    # Firefox -> dist-firefox/
+npm run build:safari     # Safari  -> dist-safari/
+npm run package[:firefox|:safari]   # build + zip
+npm run test:e2e         # playwright (loads the built extension)
 ```
 
-`npm run build` runs `tsc --noEmit` first, so a type error fails the build.
+## Rules (imported)
 
-## Architecture
+@.claude/rules/principles.md
+@.claude/rules/architecture.md
+@.claude/rules/code-style.md
+@.claude/rules/security-invariants.md
+@.claude/rules/testing.md
+@.claude/rules/release.md
 
-Service-worker-centric. The background worker orchestrates detection; content
-scripts render warnings; popup/options are React apps.
+## Skills & agents
 
-```
-src/
-├── background/   Service worker (MV3) / background script (MV2). Message hub + orchestration.
-├── content/      Injected page script: warning banner (Shadow DOM), SPA URL tracking, page analysis.
-├── popup/        React popup (badge status, history, URL check, whitelist UI, dashboard).
-├── options/      React options/settings page.
-├── detector/     Detection engine:
-│                   url-checker.ts    URL heuristics: homoglyph + digit-confusable, typosquatting,
-│                                     Damerau-Levenshtein, subdomain hiding, IP/TLD checks, punycode decode.
-│                   page-analyzer.ts  Page-content heuristics: login/CC forms, external form actions,
-│                                     TC Kimlik patterns, urgency language.
-├── blocklist/    Threat data:
-│                   bloom-filter.ts     FNV-1a Bloom filter (fast USOM membership test).
-│                   indexeddb-store.ts  USOM domains persisted in IndexedDB (confirmation lookups).
-│                   updater.ts          Remote blocklist fetch + scheduling (chrome.alarms).
-│                   usom-updater.ts     Turkish CERT (USOM) list: fetch, integrity-verify, build Bloom.
-│                   whitelist-updater.ts Dynamic allowlist + UGC domains + risky TLDs.
-├── network/      Request layer:
-│                   dnr-manager.ts      declarativeNetRequest block rules (Chrome/Safari MV3).
-│                   request-monitor.ts  webRequest monitoring + per-tab stats (Firefox blocking path).
-│                   url-check-cache.ts  In-memory TTL cache of heuristic results.
-├── storage/      idb.ts (IndexedDB), list-cache.ts (in-memory whitelist/blacklist Sets w/ parent-domain match).
-├── breach/       Local breach-DB lookup.
-├── dashboard/    Metrics + risk-score calculation for the popup dashboard.
-├── privacy/      Tracker-blocking rules.
-└── utils/        browser-polyfill, safe-fetch (size/timeout caps), whitelist-normalize, logger, types.
-```
+On-demand helpers under `.claude/`:
 
-### Detection data flow (navigate → block/warn)
+- **Skills** (`.claude/skills/`): `add-trusted-domain`, `write-detector-test`,
+  `verify-security-invariants`.
+- **Agents** (`.claude/agents/`): `detection-reviewer` — reviews detector/network
+  changes against the security invariants.
+- **Commands** (`.claude/commands/`): `/build`, `/test`, `/release-prep`.
 
-1. `chrome.tabs.onUpdated` (main_frame complete) → `background/index.ts`.
-2. **Allowlist short-circuit:** `isWhitelisted(host)` (exact + up to 3 parent
-   domains) → returns SAFE immediately, no further checks.
-3. `checkUrlConfirmed(url, protectionLevel)`:
-   - **Blacklist** (`isBlacklisted`) and **USOM Bloom** (`usomBloomTest`) →
-     DANGEROUS (early return). A USOM hit is **confirmed** against IndexedDB to
-     drop Bloom false positives.
-   - **Dynamic whitelist** → SAFE (early return).
-   - Protection `low` → blocklist only; `medium`/`high` add heuristics
-     (`high` lowers the DANGEROUS/SUSPICIOUS thresholds).
-   - `checkTyposquatting` → punycode decode → homoglyph + digit-letter
-     normalization → exact/edit-distance/substring/subdomain-hiding checks
-     against `TRUSTED_DOMAINS`.
-4. Badge updated (✓/!/?), and if DANGEROUS/SUSPICIOUS with DOM warnings enabled,
-   `SHOW_WARNING` is sent to the content script, which renders a Shadow-DOM banner.
+## The one rule that matters most
 
-## Security invariants — DO NOT REGRESS
-
-These were added/hardened deliberately. Changing detection or messaging code
-must preserve them; add a test when you touch the area.
-
-- **Privileged-message sender verification** (`background/index.ts`,
-  `isFromExtensionPage`): `SET_ENABLED`, `SETTINGS_UPDATED`, `ADD_TO_WHITELIST`,
-  `REMOVE_FROM_WHITELIST`, `CLEAR_HISTORY` are rejected unless they come from an
-  extension page (same `runtime.id`, extension-origin URL). Content scripts
-  cannot invoke them.
-- **Allowlist guards:** user input goes through `utils/whitelist-normalize.ts`
-  (strip protocol/path/query/port, reject single-label and public-suffix
-  entries). The dynamic-whitelist parser (`whitelist-updater.ts`) also rejects
-  public suffixes (`com`, `com.tr`, `gov.tr`, …) so a poisoned list can't
-  whitelist a whole TLD, and rejects a new list that shrank >50% (corruption/attack).
-- **USOM integrity** (`usom-updater.ts` `verifyIntegrity`): upstream SHA-256
-  strict match when present; locally-stored hash for the same version tag detects
-  mid-flight tampering; update aborts (previous list retained) on mismatch.
-- **URL sanitization before storage** (`sanitizeUrlForStorage`): drop query +
-  fragment before persisting history/reports — never leak tokens/OAuth codes.
-- **Fetch caps** (`utils/safe-fetch.ts`): per-source size + timeout limits on all
-  remote list fetches.
-- **Report rate limit:** `REPORT_SITE` capped at 10/hour.
-- **Logging PII contract:** log message *types*, not URLs/sender URLs, outside
-  debug mode.
-
-Security disclosures go to **guvenlik@dijitalsavunma.org** — never a public issue.
-
-## Build system (vite.config.ts)
-
-One config, multiple `--mode`s. Each produces a platform output dir; a build
-plugin copies the matching manifest (`manifest.json` / `.firefox.json` /
-`.safari.json`), `lists/`, `_locales/`, `icons/`, and the hand-written
-`list.html/js` + `whitelist.html/js` pages into the output.
-
-| Output | Modes |
-|--------|-------|
-| `dist/` (Chrome MV3) | default + `content` (content script as IIFE) |
-| `dist-firefox/` (Firefox MV2) | `firefox` + `firefox-bg` + `firefox-content` |
-| `dist-safari/` (Safari MV3) | `safari` + `safari-content` |
-
-Root-level `background.js`/`content.js`/`popup.js`/`options.js`/`chunks/` are
-**build output** and are git-ignored — never commit them; they must live in `dist/`.
-
-## Testing
-
-- **Unit (Vitest)** in `tests/`, mirroring `src/`. The detector has the densest
-  coverage (`tests/detector/*`), plus storage, network, blocklist, background
-  message handlers, and `utils/whitelist-normalize`. Add/adjust a test for any
-  detection or security-invariant change.
-- **E2E (Playwright)** in `e2e/specs/`. A fixture (`e2e/fixtures/extension.ts`)
-  loads the built extension, waits on `__alparslanE2E` readiness flags
-  (`swInitDone`, `blocklistLoaded`, `breachLoaded`), and **stubs the GitHub list
-  fetches** so tests are deterministic and offline.
-
-## Conventions
-
-- **Commits:** [Conventional Commits](https://www.conventionalcommits.org/) —
-  `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`. Reference PRs/issues
-  (`#31`, `Closes #123`).
-- **Branches:** `feat/…`, `fix/…`, `docs/…`, `refactor/…`, `test/…`
-  (`chore/…` for tooling, `release/vX.Y.Z` for release prep).
-- **Style:** ESLint + Prettier (`semi: true`, double quotes, 2-space, trailing
-  commas, width 100). Run `npm run lint` and `npm run format` before committing.
-- **PRs:** rebase on `main`, tests + lint green, CI passing, ≥1 review.
-
-## Release process
-
-The version lives in **four** files that must move in lockstep:
-`package.json`, `manifest.json`, `manifest.firefox.json`, `manifest.safari.json`.
-
-1. Bump all four (`/release-prep` automates this), `chore(release): bump version X → Y`.
-2. Merge to `main`, tag `vX.Y.Z`, and **publish a GitHub Release**. The release
-   is the trigger: `.github/workflows/release.yml` runs tests, builds all three
-   targets, and attaches `alparslan-{chrome,firefox,safari}-vX.Y.Z.zip` to the release.
-3. **Store submission is manual** (no automation, no credentials in repo):
-   - Chrome Web Store → upload `dist.zip` / the chrome release asset.
-   - Firefox AMO → upload the firefox zip.
-   - Safari → `xcrun safari-web-extension-converter dist-safari/ …` then Xcode (see README).
-
-## Gotchas
-
-- Don't commit build output to the repo root — it belongs in `dist*/`.
-- USOM/whitelist data loads asynchronously; the worker gates `CHECK_URL` on list
-  readiness. When testing detection, wait for readiness (E2E uses `__alparslanE2E`).
-- Firefox (MV2) blocks via `webRequest` (not DNR); the DNR manager no-ops there.
-- Short trusted names (≤4 chars) skip edit-distance checks by design (false-positive control).
+This is security software. Never regress a documented **security invariant**
+(`.claude/rules/security-invariants.md`), and never weaken detection, allowlist,
+or blocking without a test that proves the new behavior. When in doubt, choose
+the safer default and ask.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,184 @@
+# CLAUDE.md — Alparslan
+
+Guidance for Claude Code (and any AI agent) working in this repository. Human
+contributors should read `CONTRIBUTING.md`; this file is the machine-facing
+companion that captures the architecture, conventions, and security invariants
+that must not be regressed.
+
+## What this is
+
+**Alparslan** is a cross-browser **Manifest V3** extension that protects users
+from phishing and scam websites, with a focus on threats targeting Turkey. All
+detection runs **client-side** — browsing data never leaves the device. Ships
+for Chrome/Chromium (MV3), Firefox (MV2), and Safari (MV3).
+
+- **Language:** TypeScript. **UI:** React 18. **Build:** Vite 5.
+- **Tests:** Vitest (unit) + Playwright (E2E).
+- **Lint/format:** ESLint + Prettier.
+
+> Code, identifiers, comments, and docs are written in **English**.
+> User-facing UI strings are **Turkish** (see `_locales/tr/` and `src/i18n/tr.ts`).
+
+## Commands
+
+```bash
+npm install              # install deps (use `npm ci` for a clean, lockfile-exact install)
+npm run dev              # vite build --watch (development)
+
+npm test                 # vitest run (unit)
+npm run test:watch       # vitest watch
+npm run lint             # eslint src/
+npm run format           # prettier --write src/
+
+npm run build            # Chrome build  -> dist/
+npm run build:firefox    # Firefox build -> dist-firefox/
+npm run build:safari     # Safari build  -> dist-safari/
+
+npm run package          # build + zip   -> dist.zip
+npm run package:firefox  # build + zip   -> dist-firefox.zip
+npm run package:safari   # build + zip   -> dist-safari.zip
+
+npm run test:e2e         # playwright (loads the built extension via a fixture)
+npm run test:e2e:headed  # with a visible browser
+```
+
+`npm run build` runs `tsc --noEmit` first, so a type error fails the build.
+
+## Architecture
+
+Service-worker-centric. The background worker orchestrates detection; content
+scripts render warnings; popup/options are React apps.
+
+```
+src/
+├── background/   Service worker (MV3) / background script (MV2). Message hub + orchestration.
+├── content/      Injected page script: warning banner (Shadow DOM), SPA URL tracking, page analysis.
+├── popup/        React popup (badge status, history, URL check, whitelist UI, dashboard).
+├── options/      React options/settings page.
+├── detector/     Detection engine:
+│                   url-checker.ts    URL heuristics: homoglyph + digit-confusable, typosquatting,
+│                                     Damerau-Levenshtein, subdomain hiding, IP/TLD checks, punycode decode.
+│                   page-analyzer.ts  Page-content heuristics: login/CC forms, external form actions,
+│                                     TC Kimlik patterns, urgency language.
+├── blocklist/    Threat data:
+│                   bloom-filter.ts     FNV-1a Bloom filter (fast USOM membership test).
+│                   indexeddb-store.ts  USOM domains persisted in IndexedDB (confirmation lookups).
+│                   updater.ts          Remote blocklist fetch + scheduling (chrome.alarms).
+│                   usom-updater.ts     Turkish CERT (USOM) list: fetch, integrity-verify, build Bloom.
+│                   whitelist-updater.ts Dynamic allowlist + UGC domains + risky TLDs.
+├── network/      Request layer:
+│                   dnr-manager.ts      declarativeNetRequest block rules (Chrome/Safari MV3).
+│                   request-monitor.ts  webRequest monitoring + per-tab stats (Firefox blocking path).
+│                   url-check-cache.ts  In-memory TTL cache of heuristic results.
+├── storage/      idb.ts (IndexedDB), list-cache.ts (in-memory whitelist/blacklist Sets w/ parent-domain match).
+├── breach/       Local breach-DB lookup.
+├── dashboard/    Metrics + risk-score calculation for the popup dashboard.
+├── privacy/      Tracker-blocking rules.
+└── utils/        browser-polyfill, safe-fetch (size/timeout caps), whitelist-normalize, logger, types.
+```
+
+### Detection data flow (navigate → block/warn)
+
+1. `chrome.tabs.onUpdated` (main_frame complete) → `background/index.ts`.
+2. **Allowlist short-circuit:** `isWhitelisted(host)` (exact + up to 3 parent
+   domains) → returns SAFE immediately, no further checks.
+3. `checkUrlConfirmed(url, protectionLevel)`:
+   - **Blacklist** (`isBlacklisted`) and **USOM Bloom** (`usomBloomTest`) →
+     DANGEROUS (early return). A USOM hit is **confirmed** against IndexedDB to
+     drop Bloom false positives.
+   - **Dynamic whitelist** → SAFE (early return).
+   - Protection `low` → blocklist only; `medium`/`high` add heuristics
+     (`high` lowers the DANGEROUS/SUSPICIOUS thresholds).
+   - `checkTyposquatting` → punycode decode → homoglyph + digit-letter
+     normalization → exact/edit-distance/substring/subdomain-hiding checks
+     against `TRUSTED_DOMAINS`.
+4. Badge updated (✓/!/?), and if DANGEROUS/SUSPICIOUS with DOM warnings enabled,
+   `SHOW_WARNING` is sent to the content script, which renders a Shadow-DOM banner.
+
+## Security invariants — DO NOT REGRESS
+
+These were added/hardened deliberately. Changing detection or messaging code
+must preserve them; add a test when you touch the area.
+
+- **Privileged-message sender verification** (`background/index.ts`,
+  `isFromExtensionPage`): `SET_ENABLED`, `SETTINGS_UPDATED`, `ADD_TO_WHITELIST`,
+  `REMOVE_FROM_WHITELIST`, `CLEAR_HISTORY` are rejected unless they come from an
+  extension page (same `runtime.id`, extension-origin URL). Content scripts
+  cannot invoke them.
+- **Allowlist guards:** user input goes through `utils/whitelist-normalize.ts`
+  (strip protocol/path/query/port, reject single-label and public-suffix
+  entries). The dynamic-whitelist parser (`whitelist-updater.ts`) also rejects
+  public suffixes (`com`, `com.tr`, `gov.tr`, …) so a poisoned list can't
+  whitelist a whole TLD, and rejects a new list that shrank >50% (corruption/attack).
+- **USOM integrity** (`usom-updater.ts` `verifyIntegrity`): upstream SHA-256
+  strict match when present; locally-stored hash for the same version tag detects
+  mid-flight tampering; update aborts (previous list retained) on mismatch.
+- **URL sanitization before storage** (`sanitizeUrlForStorage`): drop query +
+  fragment before persisting history/reports — never leak tokens/OAuth codes.
+- **Fetch caps** (`utils/safe-fetch.ts`): per-source size + timeout limits on all
+  remote list fetches.
+- **Report rate limit:** `REPORT_SITE` capped at 10/hour.
+- **Logging PII contract:** log message *types*, not URLs/sender URLs, outside
+  debug mode.
+
+Security disclosures go to **guvenlik@dijitalsavunma.org** — never a public issue.
+
+## Build system (vite.config.ts)
+
+One config, multiple `--mode`s. Each produces a platform output dir; a build
+plugin copies the matching manifest (`manifest.json` / `.firefox.json` /
+`.safari.json`), `lists/`, `_locales/`, `icons/`, and the hand-written
+`list.html/js` + `whitelist.html/js` pages into the output.
+
+| Output | Modes |
+|--------|-------|
+| `dist/` (Chrome MV3) | default + `content` (content script as IIFE) |
+| `dist-firefox/` (Firefox MV2) | `firefox` + `firefox-bg` + `firefox-content` |
+| `dist-safari/` (Safari MV3) | `safari` + `safari-content` |
+
+Root-level `background.js`/`content.js`/`popup.js`/`options.js`/`chunks/` are
+**build output** and are git-ignored — never commit them; they must live in `dist/`.
+
+## Testing
+
+- **Unit (Vitest)** in `tests/`, mirroring `src/`. The detector has the densest
+  coverage (`tests/detector/*`), plus storage, network, blocklist, background
+  message handlers, and `utils/whitelist-normalize`. Add/adjust a test for any
+  detection or security-invariant change.
+- **E2E (Playwright)** in `e2e/specs/`. A fixture (`e2e/fixtures/extension.ts`)
+  loads the built extension, waits on `__alparslanE2E` readiness flags
+  (`swInitDone`, `blocklistLoaded`, `breachLoaded`), and **stubs the GitHub list
+  fetches** so tests are deterministic and offline.
+
+## Conventions
+
+- **Commits:** [Conventional Commits](https://www.conventionalcommits.org/) —
+  `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`. Reference PRs/issues
+  (`#31`, `Closes #123`).
+- **Branches:** `feat/…`, `fix/…`, `docs/…`, `refactor/…`, `test/…`
+  (`chore/…` for tooling, `release/vX.Y.Z` for release prep).
+- **Style:** ESLint + Prettier (`semi: true`, double quotes, 2-space, trailing
+  commas, width 100). Run `npm run lint` and `npm run format` before committing.
+- **PRs:** rebase on `main`, tests + lint green, CI passing, ≥1 review.
+
+## Release process
+
+The version lives in **four** files that must move in lockstep:
+`package.json`, `manifest.json`, `manifest.firefox.json`, `manifest.safari.json`.
+
+1. Bump all four (`/release-prep` automates this), `chore(release): bump version X → Y`.
+2. Merge to `main`, tag `vX.Y.Z`, and **publish a GitHub Release**. The release
+   is the trigger: `.github/workflows/release.yml` runs tests, builds all three
+   targets, and attaches `alparslan-{chrome,firefox,safari}-vX.Y.Z.zip` to the release.
+3. **Store submission is manual** (no automation, no credentials in repo):
+   - Chrome Web Store → upload `dist.zip` / the chrome release asset.
+   - Firefox AMO → upload the firefox zip.
+   - Safari → `xcrun safari-web-extension-converter dist-safari/ …` then Xcode (see README).
+
+## Gotchas
+
+- Don't commit build output to the repo root — it belongs in `dist*/`.
+- USOM/whitelist data loads asynchronously; the worker gates `CHECK_URL` on list
+  readiness. When testing detection, wait for readiness (E2E uses `__alparslanE2E`).
+- Firefox (MV2) blocks via `webRequest` (not DNR); the DNR manager no-ops there.
+- Short trusted names (≤4 chars) skip edit-distance checks by design (false-positive control).

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "tr",
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -41,5 +41,5 @@
     "webRequest",
     "declarativeNetRequest"
   ],
-  "version": "0.3.0"
+  "version": "0.4.0"
 }

--- a/manifest.safari.json
+++ b/manifest.safari.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "tr",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alparslan",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Guvenli tarayici eklentisi - Phishing ve dolandiriciliga karsi kalkan",
   "private": true,
   "type": "module",

--- a/public/_locales/tr/messages.json
+++ b/public/_locales/tr/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name"
   },
   "extensionDescription": {
-    "message": "Phishing ve dolandırıcılığa karşı güvenli tarayıcı eklentisi",
+    "message": "Oltalama ve dolandırıcılığa karşı güvenli tarayıcı eklentisi",
     "description": "Extension description"
   }
 }


### PR DESCRIPTION
## Ne / Why

Release prep + dev tooling, on one branch:

1. **`chore(release): bump version 0.3.0 → 0.4.0`** — across `package.json`,
   `manifest.json`, `manifest.firefox.json`, `manifest.safari.json` (lockstep).
2. **Claude Code collaboration setup** — `CLAUDE.md` + `.claude/` so collaborators
   and AI agents share the same architecture, conventions, and **security invariants**.

> `main` was merged into this branch after a large batch of detection work landed
> (URL canonicalizer #34, PSL/`tldts` #35, canonical domain model #36/#37,
> score-model refactor #42, detection-algorithm-strengthen #43, …). Those are now
> on `main`, so this PR's diff is just the `.claude/` setup + the version bump.

## Değişiklikler

- **`CLAUDE.md`** — thin entry point that imports the modular rules.
- **`.claude/rules/`** — `principles`, `architecture`, `code-style`,
  `security-invariants`, `testing`, `release`.
- **`.claude/skills/`** — `add-trusted-domain`, `write-detector-test`,
  `verify-security-invariants`.
- **`.claude/agents/`** — `detection-reviewer` (read-only, audits detector/network
  changes against the security invariants).
- **`.claude/commands/`** — `/build`, `/test`, `/release-prep`.
- **`.gitignore`** — track shared Claude config; ignore only `.claude/settings.local.json`.

> `.claude/settings.json` (shared permission allow-list) is added separately by a maintainer.

## Test (on the merged code)

- **Unit (vitest):** 337 passed / 17 files.
- **E2E (Playwright):** green in CI.
- **CI:** "Type check, build, unit tests" + "Playwright e2e (Chromium + extension)" both green.
- Chrome / Firefox / Safari build + package at `0.4.0`.

## Notlar

- No app-code change in this PR beyond the version string; the detection work
  itself landed via the PRs listed above.
- Release + store submission is a separate follow-up (publish GitHub Release
  `v0.4.0` → CI attaches zips → manual upload to Chrome Web Store / Firefox AMO / Safari).
