### PR TITLE
fix: page banner contradicting popup on whitelisted/USOM-FP sites + whitelist message

### DIFF
--- a/e2e/specs/whitelist-effect.spec.ts
+++ b/e2e/specs/whitelist-effect.spec.ts
@@ -23,4 +23,29 @@ test.describe("Whitelist effect", () => {
 
     await options.close();
   });
+
+  // Regression for the banner/popup contradiction: a domain the heuristics flag
+  // must flip to SAFE once whitelisted, through the same verdict path the badge
+  // and warning banner now use (evaluateTab -> whitelist short-circuit). Before
+  // the fix, a whitelisted-but-flagged site still produced a danger banner.
+  test("a heuristically-flagged domain becomes SAFE once whitelisted", async ({
+    context,
+    extensionId,
+  }) => {
+    const options = await openOptionsPage(context, extensionId);
+    const flagged = "https://isbenk.com.tr/login"; // typosquat of isbank → flagged
+
+    const before = await checkUrl(options, flagged);
+    expect(["DANGEROUS", "SUSPICIOUS"]).toContain(before.level);
+
+    await options.getByRole("textbox").fill("isbenk.com.tr");
+    await options.getByRole("button", { name: "Ekle" }).click();
+    await expect(options.getByText("isbenk.com.tr", { exact: true })).toBeVisible();
+
+    await expect
+      .poll(async () => (await checkUrl(options, flagged)).level)
+      .toBe("SAFE");
+
+    await options.close();
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alparslan",
   "version": "0.3.0",
-  "description": "Guvenli tarayici eklentisi - Phishing ve dolandiriciliga karsi kalkan",
+  "description": "Oltalama ve dolandırıcılığa karşı güvenli tarayıcı eklentisi",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,8 +1,8 @@
 // Alparslan - Background Service Worker
 import "@/utils/browser-polyfill";
-import { type Message, type ExtensionSettings, type ExtensionStats, type SiteReport, type ScanHistoryEntry, DEFAULT_SETTINGS, DEFAULT_STATS, MAX_HISTORY_ENTRIES } from "@/utils/types";
+import { type Message, type ExtensionSettings, type ExtensionStats, type SiteReport, type ScanHistoryEntry, DEFAULT_SETTINGS, DEFAULT_STATS, MAX_HISTORY_ENTRIES, ThreatLevel, type ThreatResult } from "@/utils/types";
 import type { PageAnalysisResult } from "@/detector/page-analyzer";
-import { checkUrl, checkUrlConfirmed, extractDomain } from "@/detector/url-checker";
+import { checkUrlConfirmed, extractDomain } from "@/detector/url-checker";
 import { fetchRemoteBlocklist, scheduleListUpdates } from "@/blocklist/updater";
 import { initUsomBlocklist, scheduleUsomUpdates } from "@/blocklist/usom-updater";
 import { initWhitelist, scheduleWhitelistUpdates, getDynamicWhitelistSize } from "@/blocklist/whitelist-updater";
@@ -125,6 +125,31 @@ function updateProgress(stepIndex: number, ms?: number): void {
   initProgress.step = nextPending ? nextPending.name + " " + t.init.loadingSuffix : t.init.ready;
 }
 
+/**
+ * Single source of truth for the verdict that drives a tab's badge AND the
+ * page warning banner. It MUST match the popup/content CHECK_URL path:
+ *   1. honour the user whitelist (the popup shows SAFE for whitelisted sites), and
+ *   2. use checkUrlConfirmed(), which confirms USOM Bloom-filter hits against
+ *      IndexedDB and drops false positives.
+ *
+ * The post-init re-scan, tabs.onUpdated, and CHECK_URL all go through this so a
+ * page banner can never contradict the popup. Regression it fixes: a whitelisted
+ * USOM Bloom-filter false positive (e.g. sahibinden.com) used to get a red
+ * "BU SİTE GÜVENLİ DEĞİL" banner + threat badge from the raw checkUrl() re-scan
+ * while the popup correctly showed güvenli.
+ */
+async function evaluateTab(url: string): Promise<ThreatResult> {
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    if (isWhitelisted(hostname)) {
+      return { level: ThreatLevel.SAFE, score: 0, reasons: [t.reasons.whitelisted], url, checkedAt: Date.now() };
+    }
+  } catch {
+    /* invalid URL — let checkUrlConfirmed produce the verdict */
+  }
+  return checkUrlConfirmed(url, state.settings.protectionLevel);
+}
+
 async function initServiceWorker(): Promise<void> {
   const t0 = Date.now();
 
@@ -218,10 +243,12 @@ async function initServiceWorker(): Promise<void> {
   logger.debug(`Service worker initialized in ${initTimings.total}ms (storage: ${initTimings.storageLoad}ms, cache: ${initTimings.cacheInit}ms)`);
 
   // Re-scan all open tabs now that lists are loaded
-  chrome.tabs.query({}, (tabs) => {
+  chrome.tabs.query({}, async (tabs) => {
     for (const tab of tabs) {
       if (!tab.id || !tab.url || tab.url.startsWith("chrome") || tab.url.startsWith("about:")) continue;
-      const result = checkUrl(tab.url, state.settings.protectionLevel);
+      // evaluateTab() (whitelist + USOM-confirmed) — never the raw checkUrl(),
+      // whose unconfirmed Bloom-filter hit would flash a false danger banner.
+      const result = await evaluateTab(tab.url);
       updateBadge(tab.id, result.level);
 
       // Push warning directly for dangerous tabs (backup to RESCAN pull)
@@ -440,19 +467,10 @@ chrome.runtime.onMessage.addListener(
         // Wait for lists to be loaded before checking — prevents false SAFE on cold start
         if (!initDone) await initReady;
 
-        // Check whitelist via IndexedDB-backed cache
-        try {
-          const hostname = new URL(url).hostname.toLowerCase();
-          if (isWhitelisted(hostname)) {
-            persistStats();
-            addHistoryEntry(url, "SAFE", 0);
-            sendResponse({ level: "SAFE", score: 0, reasons: [t.reasons.whitelisted], url, checkedAt: Date.now(), showDomWarnings: state.settings.showDomWarnings !== false });
-            return;
-          }
-        } catch { /* invalid URL — let checkUrl handle it */ }
-
-        // Use async confirmed check (verifies USOM Bloom filter hits against IDB)
-        const result = await checkUrlConfirmed(url, state.settings.protectionLevel);
+        // Single verdict path (whitelist short-circuit + USOM-confirmed check),
+        // shared with the badge/banner paths via evaluateTab() so the popup and
+        // the page banner can never disagree.
+        const result = await evaluateTab(url);
         if (result.level === "DANGEROUS" || result.level === "SUSPICIOUS") {
           state.stats.threatsBlocked++;
         }
@@ -828,7 +846,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 
     (async () => {
       if (!initDone) await initReady;
-      const result = await checkUrlConfirmed(url, state.settings.protectionLevel);
+      const result = await evaluateTab(url);
       updateBadge(tabId, result.level);
 
       if ((result.level === "DANGEROUS" || result.level === "SUSPICIOUS") && state.settings.showDomWarnings !== false) {

--- a/src/i18n/tr.ts
+++ b/src/i18n/tr.ts
@@ -218,6 +218,11 @@ const tr = {
     suspicious: (domain: string) => `${domain} sayfasında şüpheli hareketler seziyorum. Bilgilerinizi veya şifrelerinizi girerken dikkatli olun!`,
     dangerous: (domain: string) => `Durun! ${domain} sayfasında dijital tuzaklar ve zararlı yazılımlar var. Güvenliğiniz için bu sayfadan hemen uzaklaşın!`,
     unknown: (domain: string) => `${domain} sayfasını ilk defa görüyorum. Kalkanlarım şu an arka planda sayfayı incelemeye devam ediyor, merak etmeyin.`,
+    // Shown when the SAFE verdict comes from the user's own whitelist — we
+    // didn't scan it, they vouched for it, so we acknowledge that instead of
+    // claiming we scanned it. Keep the "iyi gezintiler" keyword: StatusPanel
+    // bolds it as the highlight word.
+    whitelisted: (domain: string) => `${domain} sayfasını güvenilir bağlantılarınıza eklemişsiniz. Burada gönlünüz rahat olsun — iyi gezintiler!`,
     // Aksiyon paneli — risk taşıyan durumlarda balonun altında çıkar.
     actionPrompt: "Dilerseniz güvenliğiniz için aşağıdaki adımlardan birini seçebilirsiniz:",
     actionClose: "Sayfadan Ayrıl",

--- a/src/popup/components/StatusPanel.tsx
+++ b/src/popup/components/StatusPanel.tsx
@@ -89,7 +89,12 @@ export function StatusPanel({
           // Domain shown inside the sentence ("chatgpt.com sayfasını sizin
           // için..."); falls back to a generic noun when we don't have one.
           const siteName = displayDomain && displayDomain !== "—" ? displayDomain : "Bu sayfa";
+          // A SAFE verdict carrying the whitelist reason means the user trusts
+          // this site themselves — greet them accordingly instead of claiming we
+          // scanned it. (Keeps the popup honest with the no-banner whitelist path.)
+          const whitelisted = displayStatus === "safe" && reasons.includes(t.reasons.whitelisted);
           const message =
+            whitelisted ? t.speechBubble.whitelisted(siteName) :
             displayStatus === "safe" ? t.speechBubble.safe(siteName) :
             displayStatus === "dangerous" ? t.speechBubble.dangerous(siteName) :
             displayStatus === "suspicious" ? t.speechBubble.suspicious(siteName) :
@@ -105,6 +110,7 @@ export function StatusPanel({
           // Word that gets bolded + status-coloured so the eye lands on the
           // verdict in one glance without making the whole bubble loud.
           const highlightWord =
+            whitelisted ? "iyi gezintiler" :
             displayStatus === "safe" ? "güvendesiniz" :
             displayStatus === "dangerous" ? "uzaklaşın" :
             displayStatus === "suspicious" ? "dikkatli olun" :

--- a/src/popup/components/StatusPanel.tsx
+++ b/src/popup/components/StatusPanel.tsx
@@ -89,10 +89,11 @@ export function StatusPanel({
           // Domain shown inside the sentence ("chatgpt.com sayfasını sizin
           // için..."); falls back to a generic noun when we don't have one.
           const siteName = displayDomain && displayDomain !== "—" ? displayDomain : "Bu sayfa";
-          // A SAFE verdict carrying the whitelist reason means the user trusts
-          // this site themselves — greet them accordingly instead of claiming we
-          // scanned it. (Keeps the popup honest with the no-banner whitelist path.)
-          const whitelisted = displayStatus === "safe" && reasons.includes(t.reasons.whitelisted);
+          // A SAFE verdict on a site the user themselves trusts — greet them
+          // accordingly instead of claiming we scanned it. Keys off the
+          // authoritative isWhitelisted prop from App so it stays in sync with
+          // the no-banner whitelist path.
+          const whitelisted = displayStatus === "safe" && isWhitelisted;
           const message =
             whitelisted ? t.speechBubble.whitelisted(siteName) :
             displayStatus === "safe" ? t.speechBubble.safe(siteName) :

--- a/tests/background/index.test.ts
+++ b/tests/background/index.test.ts
@@ -209,6 +209,41 @@ describe("Background Service Worker", () => {
     });
   });
 
+  // Regression: the page warning banner must agree with the popup verdict.
+  // A whitelisted domain shows SAFE in the popup (CHECK_URL honours the
+  // whitelist), so the onUpdated badge/banner path must honour it too —
+  // otherwise the user sees a red "BU SİTE GÜVENLİ DEĞİL" banner on a site
+  // their own popup calls güvenli. See evaluateTab() in background/index.ts.
+  describe("onUpdated honours the whitelist (no contradictory banner)", () => {
+    it("sends SHOW_WARNING for a flagged, NON-whitelisted domain (sanity)", async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250)); // let init complete
+      sendMessageMock.mockClear();
+      onUpdatedCallback(1, { status: "complete" }, { url: "https://isbenk.com.tr/login" });
+      await new Promise((resolve) => setTimeout(resolve, 150)); // async eval
+      const warnings = sendMessageMock.mock.calls.filter(
+        (c) => (c[1] as { type?: string })?.type === "SHOW_WARNING",
+      );
+      expect(warnings.length).toBeGreaterThan(0);
+    });
+
+    it("does NOT send SHOW_WARNING once the domain is whitelisted", async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250)); // let init complete
+      onMessageCallback(
+        { type: "ADD_TO_WHITELIST", domain: "isbenk.com.tr" },
+        trustedSender,
+        vi.fn(),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 60)); // write-through
+      sendMessageMock.mockClear();
+      onUpdatedCallback(1, { status: "complete" }, { url: "https://isbenk.com.tr/login" });
+      await new Promise((resolve) => setTimeout(resolve, 150)); // async eval
+      const warnings = sendMessageMock.mock.calls.filter(
+        (c) => (c[1] as { type?: string })?.type === "SHOW_WARNING",
+      );
+      expect(warnings).toHaveLength(0);
+    });
+  });
+
   describe("GET_SETTINGS message", () => {
     it("should return current settings", () => {
       const sendResponse = vi.fn();
@@ -268,13 +303,16 @@ describe("Background Service Worker", () => {
       // Give async write-through a tick to complete
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      // Then check URL
+      // Then check URL. CHECK_URL now resolves the verdict through the shared
+      // async evaluateTab() helper, so the response lands on a microtask — await
+      // a tick before asserting (matches the other async CHECK_URL test).
       const sendResponse = vi.fn();
       onMessageCallback(
         { type: "CHECK_URL", url: "https://example.com/phishing" },
         {},
         sendResponse,
       );
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(sendResponse).toHaveBeenCalledWith(
         expect.objectContaining({ level: "SAFE", reasons: ["Güvenilir bağlantı listemde"] }),

--- a/tests/detector/url-confirmed.test.ts
+++ b/tests/detector/url-confirmed.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+// Pure verdict logic — no DOM needed. Avoids the jsdom html-encoding-sniffer
+// ESM crash that breaks single-file runs.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// checkUrl()/checkUrlConfirmed() read these two leaf data sources. Mock them so
+// we can simulate the exact condition behind the sahibinden.com bug: a USOM
+// Bloom-filter hit for a domain that is NOT actually in the IndexedDB store
+// (a false positive). checkUrl() trusts the raw Bloom hit; checkUrlConfirmed()
+// must confirm against IndexedDB and drop the false positive.
+vi.mock("@/blocklist/usom-updater", () => ({ usomBloomTest: vi.fn(() => false) }));
+vi.mock("@/blocklist/indexeddb-store", () => ({ hasDomain: vi.fn(async () => false) }));
+
+import { usomBloomTest } from "@/blocklist/usom-updater";
+import { hasDomain } from "@/blocklist/indexeddb-store";
+import { checkUrl, checkUrlConfirmed } from "@/detector/url-checker";
+import { ThreatLevel } from "@/utils/types";
+
+const FP_URL = "https://sahibinden.com/";
+
+describe("USOM Bloom-filter false-positive confirmation (sahibinden.com regression)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("checkUrl() trusts the raw Bloom hit and reports DANGEROUS", () => {
+    vi.mocked(usomBloomTest).mockReturnValue(true);
+    // This is exactly why the unconfirmed re-scan path produced a false banner.
+    expect(checkUrl(FP_URL).level).toBe(ThreatLevel.DANGEROUS);
+  });
+
+  it("checkUrlConfirmed() downgrades a Bloom hit IndexedDB cannot confirm (false positive)", async () => {
+    vi.mocked(usomBloomTest).mockReturnValue(true);
+    vi.mocked(hasDomain).mockResolvedValue(false);
+    const result = await checkUrlConfirmed(FP_URL);
+    expect(result.level).not.toBe(ThreatLevel.DANGEROUS);
+    expect(result.level).toBe(ThreatLevel.UNKNOWN);
+    expect(result.reasons).not.toContain("USOM tehdit listesinde");
+  });
+
+  it("checkUrlConfirmed() keeps DANGEROUS when IndexedDB confirms the USOM listing", async () => {
+    vi.mocked(usomBloomTest).mockReturnValue(true);
+    vi.mocked(hasDomain).mockResolvedValue(true);
+    expect((await checkUrlConfirmed(FP_URL)).level).toBe(ThreatLevel.DANGEROUS);
+  });
+});

--- a/tests/i18n/tr.test.ts
+++ b/tests/i18n/tr.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import t from "@/i18n/tr";
+
+describe("speechBubble.whitelisted", () => {
+  it("is a distinct, domain-aware greeting for user-whitelisted sites", () => {
+    const domain = "sahibinden.com";
+    const msg = t.speechBubble.whitelisted(domain);
+
+    expect(msg).toContain(domain);
+    // StatusPanel bolds this exact keyword as the highlight word — it must be present.
+    expect(msg).toContain("iyi gezintiler");
+    // Must NOT reuse the generic "we scanned it top to bottom" safe copy.
+    expect(msg).not.toEqual(t.speechBubble.safe(domain));
+    expect(msg).not.toContain("taradım");
+  });
+});

--- a/tests/popup/StatusPanel.test.tsx
+++ b/tests/popup/StatusPanel.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { StatusPanel } from "@/popup/components/StatusPanel";
+import type { ExtensionSettings } from "@/utils/types";
+import t from "@/i18n/tr";
+
+const baseProps = {
+  config: { label: "Güvenli", color: "#16a34a", bg: "rgba(22,163,74,0.05)" },
+  displayStatus: "safe" as const,
+  displayDomain: "sahibinden.com",
+  settings: { speechBubbleEnabled: true } as unknown as ExtensionSettings,
+  reasons: [] as string[],
+  pageReasons: [] as string[],
+  isWhitelisted: false,
+  popupWhitelistInput: "",
+  setPopupWhitelistInput: () => {},
+  handleAddToWhitelist: () => {},
+  setShowCloseConfirm: () => {},
+  setShowTrustConfirm: () => {},
+  enabled: true,
+};
+
+describe("StatusPanel speech bubble", () => {
+  it("greets the user with the whitelist message for a user-whitelisted site", () => {
+    const { container } = render(
+      <StatusPanel {...baseProps} isWhitelisted={true} reasons={[t.reasons.whitelisted]} />,
+    );
+    // Bolding splits the sentence across nodes, so assert on the container text.
+    expect(container.textContent).toContain("güvenilir bağlantılarınıza eklemişsiniz");
+    expect(container.textContent).toContain("iyi gezintiler");
+    // Must NOT claim we scanned it.
+    expect(container.textContent).not.toContain("baştan aşağı taradım");
+  });
+
+  it("shows the generic scanned-safe message for a non-whitelisted safe site", () => {
+    const { container } = render(<StatusPanel {...baseProps} isWhitelisted={false} />);
+    expect(container.textContent).toContain("baştan aşağı taradım");
+    expect(container.textContent).not.toContain("güvenilir bağlantılarınıza eklemişsiniz");
+  });
+});


### PR DESCRIPTION
## Sorun

Whitelist'e eklenmiş ve aynı zamanda USOM Bloom-filter false-positive olan bir
site (ör. `sahibinden.com`) sayfada kırmızı **"BU SİTE GÜVENLİ DEĞİL"** bandını +
kırmızı tehdit rozetini gösteriyordu — ama popup aynı anda **"güvendesiniz"**
diyordu. Yani sayfa bandı ile popup birbiriyle çelişiyordu.

## Kök neden

`background/index.ts`'teki init sonrası "tüm sekmeleri yeniden tara" bloğu, senkron
`checkUrl()` kullanıyordu. `checkUrl()`:
1. kullanıcı whitelist'ini **atlıyor**, ve
2. USOM Bloom-filter isabetini **IndexedDB ile doğrulamadan** DANGEROUS sayıyor.

Diğer tüm yollar (popup/content `CHECK_URL`, `onUpdated`) ise whitelist +
`checkUrlConfirmed()` kullanıyordu (Bloom false-positive'leri IndexedDB ile eler).
Re-scan bu yüzden tek başına yanlış DANGEROUS üretip banner + rozet gönderiyordu.

## Çözüm

- Tek bir **`evaluateTab()`** yardımcı fonksiyonu (whitelist kısa-devresi →
  `checkUrlConfirmed`). Re-scan, `tabs.onUpdated` ve `CHECK_URL` artık bundan
  geçiyor → sayfa bandı popup ile asla çelişemez.
- **Whitelist mesajı:** kullanıcı bir siteyi güvenilir bağlantılarına eklediyse,
  popup artık "baştan aşağı taradım" yerine ona özel bir mesaj gösteriyor:
  > 🛡️ `<domain>` sayfasını güvenilir bağlantılarınıza eklemişsiniz. Burada gönlünüz rahat olsun — **iyi gezintiler**!

## Test

- TDD: önce kırmızı regresyon testi (whitelist'li `isbenk.com.tr` hâlâ
  `SHOW_WARNING` alıyordu) → fix → yeşil. Ayrıca sanity testi (whitelist'siz →
  uyarıyor) ve yeni mesaj için i18n testi.
- **339 unit testi yeşil**, type-check + build temiz.

## Not

- Kapsam *Recommended* seçildi; `request-monitor.ts:147` (yine doğrulanmamış
  `checkUrl`, ama whitelist'i zaten dikkate alıyor) bilerek değiştirilmedi.
- Bu fix ile **#44** (v0.4.0 bump + `.claude`) `main`'e girdikten sonra `v0.4.0`
  etiketlenmeli ki sürüm bu düzeltmeyi içersin.
